### PR TITLE
added a few null checks

### DIFF
--- a/src/stylesheet.c
+++ b/src/stylesheet.c
@@ -39,6 +39,9 @@ css_error css__stylesheet_string_add(css_stylesheet *sheet, lwc_string *string, 
 {
 	uint32_t new_string_number; /* The string number count */
 
+	if (string == NULL)
+		return CSS_BADPARM;
+
 	/* search for the string in the existing vector */
 	for (new_string_number = 0;
 	     new_string_number < sheet->string_vector_c;
@@ -1151,7 +1154,9 @@ css_error css__stylesheet_rule_destroy(css_stylesheet *sheet, css_rule *rule)
 	{
 		css_rule_import *import = (css_rule_import *) rule;
 
-		lwc_string_unref(import->url);
+		if (import->url != NULL)
+			lwc_string_unref(import->url);
+
 		if (import->media != NULL) {
 			css__mq_query_destroy(import->media);
 		}


### PR DESCRIPTION
This fixes the first crash found by running the clusterfuzz-lite fuzzer.

Question: since free() is guaranteed safe for NULL, why not `lwc_string_unref` safe for NULL as well ?  There is an assertion in the code, but that doesn't protect production code.