### PR TITLE
do not add rule to non-MEDIA parent

### DIFF
--- a/src/parse/language.c
+++ b/src/parse/language.c
@@ -289,6 +289,10 @@ css_error handleStartRuleset(css_language *c, const parserutils_vector *vector)
 	if (cur != NULL && cur->type != CSS_PARSER_START_STYLESHEET)
 		parent_rule = cur->data;
 
+	/* Do not add rule to non-MEDIA parent */
+    if (parent_rule != NULL && parent_rule->type != CSS_RULE_MEDIA)
+    	return CSS_INVALID;
+
 	error = css__stylesheet_rule_create(c->sheet, CSS_RULE_SELECTOR, &rule);
 	if (error != CSS_OK)
 		return error;


### PR DESCRIPTION
Here is the crash file and stack trace

[crash-f9e95103fde5422aa9356ecfb7c191aa87a4c3c8.css](https://github.com/user-attachments/files/23563201/crash-f9e95103fde5422aa9356ecfb7c191aa87a4c3c8.css)


```
Running: /out/crash-f9e95103fde5422aa9356ecfb7c191aa87a4c3c8
css_parse_fuzzer: ../src/stylesheet.c:1444: css_error css__stylesheet_add_rule(css_stylesheet *, css_rule *, css_rule *): Assertion `parent->type == CSS_RULE_MEDIA' failed.
==13== ERROR: libFuzzer: deadly signal
    #0 0x55b6858a14c1 in __sanitizer_print_stack_trace /src/llvm-project/compiler-rt/lib/asan/asan_stack.cpp:87:3
    #1 0x55b685793268 in fuzzer::PrintStackTrace() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:210:5
    #2 0x55b685775db5 in fuzzer::Fuzzer::CrashCallback() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:231:3
    #3 0x7f2327e5241f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1441f) (BuildId: 9753720502573b97dbac595b61fd72c2df18e078)
    #4 0x7f2327c4600a in raise (/lib/x86_64-linux-gnu/libc.so.6+0x4300a) (BuildId: 5792732f783158c66fb4f3756458ca24e46e827d)
    #5 0x7f2327c25858 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x22858) (BuildId: 5792732f783158c66fb4f3756458ca24e46e827d)
    #6 0x7f2327c25728  (/lib/x86_64-linux-gnu/libc.so.6+0x22728) (BuildId: 5792732f783158c66fb4f3756458ca24e46e827d)
    #7 0x7f2327c36fd5 in __assert_fail (/lib/x86_64-linux-gnu/libc.so.6+0x33fd5) (BuildId: 5792732f783158c66fb4f3756458ca24e46e827d)
    #8 0x55b685931942 in css__stylesheet_add_rule /src/libcss/build/../src/stylesheet.c:1444:3
    #9 0x55b685936e53 in handleStartRuleset /src/libcss/build/../src/parse/language.c:313:10
    #10 0x55b685932f7a in language_handle_event /src/libcss/build/../src/parse/language.c:211:10
    #11 0x55b68594afee in parseRuleset /src/libcss/build/../src/parse/parse.c:942:8
    #12 0x55b68594907d in css__parser_parse_chunk /src/libcss/build/../src/parse/parse.c:322:11
    #13 0x55b6858db3cb in parse_css /src/libcss/test/fuzzers/css_parse_fuzzer.cc:260:20
    #14 0x55b6858db3cb in LLVMFuzzerTestOneInput /src/libcss/test/fuzzers/css_parse_fuzzer.cc:332:3
    #15 0x55b68577749d in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
    #16 0x55b685762212 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:329:6
    #17 0x55b6857680e0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:865:9
    #18 0x55b685793c12 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #19 0x7f2327c27082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 5792732f783158c66fb4f3756458ca24e46e827d)
    #20 0x55b68575b2fd in _start (/out/css_parse_fuzzer+0x1182fd)
```