### PR TITLE
Remove commits causing fuzzer to crash on null pointer

### DIFF
--- a/src/parse/language.c
+++ b/src/parse/language.c
@@ -169,7 +169,8 @@ css_error css__language_destroy(css_language *language)
 	if (language == NULL)
 		return CSS_BADPARM;
 
-	lwc_string_unref(language->default_namespace);
+	if (language->default_namespace != NULL)
+		lwc_string_unref(language->default_namespace);
 
 	if (language->namespaces != NULL) {
 		for (i = 0; i < language->num_namespaces; i++) {
@@ -854,7 +855,8 @@ css_error addNamespace(css_language *c, lwc_string *prefix, lwc_string *uri)
 {
 	if (prefix == NULL) {
 		/* Replace default namespace */
-		lwc_string_unref(c->default_namespace);
+		if (c->default_namespace != NULL)
+			lwc_string_unref(c->default_namespace);
 
 		/* Special case: if new namespace uri is "", use NULL */
 		if (lwc_string_length(uri) == 0)
@@ -890,7 +892,8 @@ css_error addNamespace(css_language *c, lwc_string *prefix, lwc_string *uri)
 		}
 
 		/* Replace namespace URI */
-		lwc_string_unref(c->namespaces[idx].uri);
+		if (c->namespaces[idx].uri != NULL)
+			lwc_string_unref(c->namespaces[idx].uri);
 
 		/* Special case: if new namespace uri is "", use NULL */
 		if (lwc_string_length(uri) == 0)

--- a/src/select/autogenerated_propset.h
+++ b/src/select/autogenerated_propset.h
@@ -127,7 +127,8 @@ static inline css_error set_background_image(css_computed_style *style, uint8_t
 		style->i.background_image = NULL;
 	}
 	
-	lwc_string_unref(old_string);
+	if (old_string != NULL)
+		lwc_string_unref(old_string);
 	
 	return CSS_OK;
 }
@@ -1439,7 +1440,8 @@ static inline css_error set_list_style_image(css_computed_style *style, uint8_t
 		style->i.list_style_image = NULL;
 	}
 	
-	lwc_string_unref(old_string);
+	if (old_string != NULL)
+		lwc_string_unref(old_string);
 	
 	return CSS_OK;
 }

--- a/src/select/computed.c
+++ b/src/select/computed.c
@@ -192,8 +192,11 @@ css_error css_computed_style_destroy(css_computed_style *style)
 		free(style->quotes);
 	}
 
-	lwc_string_unref(style->i.list_style_image);
-	lwc_string_unref(style->i.background_image);
+	if (style->i.list_style_image != NULL)
+		lwc_string_unref(style->i.list_style_image);
+
+	if (style->i.background_image != NULL)
+		lwc_string_unref(style->i.background_image);
 
 	if (style->calc != NULL)
 		css_calculator_unref(style->calc);

--- a/src/select/font_face.c
+++ b/src/select/font_face.c
@@ -16,7 +16,9 @@ static void font_faces_srcs_destroy(css_font_face *font_face)
 	css_font_face_src *srcs = font_face->srcs;
 
 	for (i = 0; i < font_face->n_srcs; ++i) {
-		lwc_string_unref(srcs[i].location);
+		if (srcs[i].location != NULL) {
+			lwc_string_unref(srcs[i].location);
+		}
 	}
 
 	free(srcs);
@@ -67,7 +69,8 @@ css_error css__font_face_destroy(css_font_face *font_face)
 	if (font_face == NULL)
 		return CSS_BADPARM;
 
-	lwc_string_unref(font_face->font_family);
+	if (font_face->font_family != NULL)
+		lwc_string_unref(font_face->font_family);
 
 	if (font_face->srcs != NULL)
 		font_faces_srcs_destroy(font_face);
@@ -93,7 +96,8 @@ css_error css__font_face_set_font_family(css_font_face *font_face,
 	if (font_face == NULL || font_family == NULL)
 		return CSS_BADPARM;
 
-	lwc_string_unref(font_face->font_family);
+	if (font_face->font_family != NULL)
+		lwc_string_unref(font_face->font_family);
 
 	font_face->font_family = lwc_string_ref(font_family);
 

--- a/src/select/properties/background_image.c
+++ b/src/select/properties/background_image.c
@@ -27,7 +27,8 @@ css_error css__set_background_image_from_hint(const css_hint *hint,
 
 	error = set_background_image(style, hint->status, hint->data.string);
 
-	lwc_string_unref(hint->data.string);
+	if (hint->data.string != NULL)
+		lwc_string_unref(hint->data.string);
 
 	return error;
 }

--- a/src/select/properties/list_style_image.c
+++ b/src/select/properties/list_style_image.c
@@ -27,7 +27,8 @@ css_error css__set_list_style_image_from_hint(const css_hint *hint,
 
 	error = set_list_style_image(style, hint->status, hint->data.string);
 
-	lwc_string_unref(hint->data.string);
+	if (hint->data.string != NULL)
+		lwc_string_unref(hint->data.string);
 
 	return error;
 }

--- a/src/select/select.c
+++ b/src/select/select.c
@@ -1031,9 +1031,17 @@ static void css_select__finalise_selection_state(
 		}
 	}
 
-	lwc_string_unref(state->id);
-	lwc_string_unref(state->element.ns);
-	lwc_string_unref(state->element.name);
+	if (state->id != NULL) {
+		lwc_string_unref(state->id);
+	}
+
+	if (state->element.ns != NULL) {
+		lwc_string_unref(state->element.ns);
+	}
+
+	if (state->element.name != NULL){
+		lwc_string_unref(state->element.name);
+	}
 
 	if (state->revert != NULL) {
 		for (size_t i = 0; i < CSS_ORIGIN_AUTHOR; i++) {

--- a/src/select/select_generator.py
+++ b/src/select/select_generator.py
@@ -588,7 +588,10 @@ class CSSGroup:
                     t.indent(-1)
                     t.append('}')
                     t.append()
+                    t.append('if ({} != NULL)'.format(old_n))
+                    t.indent(1)
                     t.append('lwc_string_unref({});'.format(old_n))
+                    t.indent(-1)
 
                 elif v.name == 'string_arr' or v.name == 'counter_arr':
                     iter_var = 's' if v.name == 'string_arr' else 'c'

--- a/src/select/strings.c
+++ b/src/select/strings.c
@@ -200,35 +200,65 @@ css_error css_select_strings_intern(css_select_strings *str)
 
 void css_select_strings_unref(css_select_strings *str)
 {
-	lwc_string_unref(str->universal);
-	lwc_string_unref(str->first_child);
-	lwc_string_unref(str->link);
-	lwc_string_unref(str->visited);
-	lwc_string_unref(str->hover);
-	lwc_string_unref(str->active);
-	lwc_string_unref(str->focus);
-	lwc_string_unref(str->nth_child);
-	lwc_string_unref(str->nth_last_child);
-	lwc_string_unref(str->nth_of_type);
-	lwc_string_unref(str->nth_last_of_type);
-	lwc_string_unref(str->last_child);
-	lwc_string_unref(str->first_of_type);
-	lwc_string_unref(str->last_of_type);
-	lwc_string_unref(str->only_child);
-	lwc_string_unref(str->only_of_type);
-	lwc_string_unref(str->root);
-	lwc_string_unref(str->empty);
-	lwc_string_unref(str->target);
-	lwc_string_unref(str->lang);
-	lwc_string_unref(str->enabled);
-	lwc_string_unref(str->disabled);
-	lwc_string_unref(str->checked);
-	lwc_string_unref(str->first_line);
-	lwc_string_unref(str->first_letter);
-	lwc_string_unref(str->before);
-	lwc_string_unref(str->after);
+	if (str->universal != NULL)
+		lwc_string_unref(str->universal);
+	if (str->first_child != NULL)
+		lwc_string_unref(str->first_child);
+	if (str->link != NULL)
+		lwc_string_unref(str->link);
+	if (str->visited != NULL)
+		lwc_string_unref(str->visited);
+	if (str->hover != NULL)
+		lwc_string_unref(str->hover);
+	if (str->active != NULL)
+		lwc_string_unref(str->active);
+	if (str->focus != NULL)
+		lwc_string_unref(str->focus);
+	if (str->nth_child != NULL)
+		lwc_string_unref(str->nth_child);
+	if (str->nth_last_child != NULL)
+		lwc_string_unref(str->nth_last_child);
+	if (str->nth_of_type != NULL)
+		lwc_string_unref(str->nth_of_type);
+	if (str->nth_last_of_type != NULL)
+		lwc_string_unref(str->nth_last_of_type);
+	if (str->last_child != NULL)
+		lwc_string_unref(str->last_child);
+	if (str->first_of_type != NULL)
+		lwc_string_unref(str->first_of_type);
+	if (str->last_of_type != NULL)
+		lwc_string_unref(str->last_of_type);
+	if (str->only_child != NULL)
+		lwc_string_unref(str->only_child);
+	if (str->only_of_type != NULL)
+		lwc_string_unref(str->only_of_type);
+	if (str->root != NULL)
+		lwc_string_unref(str->root);
+	if (str->empty != NULL)
+		lwc_string_unref(str->empty);
+	if (str->target != NULL)
+		lwc_string_unref(str->target);
+	if (str->lang != NULL)
+		lwc_string_unref(str->lang);
+	if (str->enabled != NULL)
+		lwc_string_unref(str->enabled);
+	if (str->disabled != NULL)
+		lwc_string_unref(str->disabled);
+	if (str->checked != NULL)
+		lwc_string_unref(str->checked);
+	if (str->first_line != NULL)
+		lwc_string_unref(str->first_line);
+	if (str->first_letter != NULL)
+		lwc_string_unref(str->first_letter);
+	if (str->before != NULL)
+		lwc_string_unref(str->before);
+	if (str->after != NULL)
+		lwc_string_unref(str->after);
 
-	lwc_string_unref(str->width);
-	lwc_string_unref(str->height);
-	lwc_string_unref(str->prefers_color_scheme);
+	if (str->width != NULL)
+		lwc_string_unref(str->width);
+	if (str->height != NULL)
+		lwc_string_unref(str->height);
+	if (str->prefers_color_scheme != NULL)
+		lwc_string_unref(str->prefers_color_scheme);
 }

--- a/src/stylesheet.c
+++ b/src/stylesheet.c
@@ -854,7 +854,8 @@ css_error css__stylesheet_selector_destroy(css_stylesheet *sheet,
 		d = c->combinator;
 
 		for (detail = &c->data; detail;) {
-			lwc_string_unref(detail->qname.ns);
+			if (detail->qname.ns != NULL)
+				lwc_string_unref(detail->qname.ns);
 			lwc_string_unref(detail->qname.name);
 
 			if (detail->value_type ==
@@ -873,7 +874,8 @@ css_error css__stylesheet_selector_destroy(css_stylesheet *sheet,
 	}
 
 	for (detail = &selector->data; detail;) {
-		lwc_string_unref(detail->qname.ns);
+		if (detail->qname.ns != NULL)
+			lwc_string_unref(detail->qname.ns);
 		lwc_string_unref(detail->qname.name);
 
 		if (detail->value_type == CSS_SELECTOR_DETAIL_VALUE_STRING &&
@@ -1152,7 +1154,8 @@ css_error css__stylesheet_rule_destroy(css_stylesheet *sheet, css_rule *rule)
 	{
 		css_rule_import *import = (css_rule_import *) rule;
 
-		lwc_string_unref(import->url);
+		if (import->url != NULL)
+			lwc_string_unref(import->url);
 
 		if (import->media != NULL) {
 			css__mq_query_destroy(import->media);


### PR DESCRIPTION
Hi Michael,
Just letting you know that after the last four commits removing null checks, the clusterfuzzlite
fuzzer now crashes on pretty much all of the spots where null checks used to be.
Attached is one such crash file.

Thanks,
Aaron

[crash-2d2edbc3a7548eb7ee1a4c97913bcadfc069c8f6.zip](https://github.com/user-attachments/files/23913603/crash-2d2edbc3a7548eb7ee1a4c97913bcadfc069c8f6.zip)
