### PR TITLE
Update select code-generator

### DIFF
--- a/src/select/autogenerated_computed.h
+++ b/src/select/autogenerated_computed.h
@@ -215,7 +215,7 @@ struct css_computed_style_i {
  * counter_increment; color; background_image
  */
 	uint32_t bits[15];
-	
+
 	css_color background_color;
 	lwc_string *background_image;
 	css_fixed background_position_a;
@@ -281,14 +281,14 @@ struct css_computed_style_i {
 
 struct css_computed_style {
 	struct css_computed_style_i i;
-	
+
 	css_computed_content_item *content;
 	css_computed_counter *counter_increment;
 	css_computed_counter *counter_reset;
 	lwc_string **cursor;
 	lwc_string **font_family;
 	lwc_string **quotes;
-	
+
 	struct css_computed_style *next;
 	uint32_t count;
 	uint32_t bin;

--- a/src/select/autogenerated_propget.h
+++ b/src/select/autogenerated_propget.h
@@ -18,7 +18,7 @@ static inline uint8_t get_align_content_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ALIGN_CONTENT_INDEX];
 	bits &= ALIGN_CONTENT_MASK;
 	bits >>= ALIGN_CONTENT_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -29,10 +29,10 @@ static inline uint8_t get_align_content(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ALIGN_CONTENT_INDEX];
 	bits &= ALIGN_CONTENT_MASK;
 	bits >>= ALIGN_CONTENT_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef ALIGN_CONTENT_INDEX
@@ -48,7 +48,7 @@ static inline uint8_t get_align_items_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ALIGN_ITEMS_INDEX];
 	bits &= ALIGN_ITEMS_MASK;
 	bits >>= ALIGN_ITEMS_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -59,10 +59,10 @@ static inline uint8_t get_align_items(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ALIGN_ITEMS_INDEX];
 	bits &= ALIGN_ITEMS_MASK;
 	bits >>= ALIGN_ITEMS_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef ALIGN_ITEMS_INDEX
@@ -78,7 +78,7 @@ static inline uint8_t get_align_self_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ALIGN_SELF_INDEX];
 	bits &= ALIGN_SELF_MASK;
 	bits >>= ALIGN_SELF_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -89,10 +89,10 @@ static inline uint8_t get_align_self(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ALIGN_SELF_INDEX];
 	bits &= ALIGN_SELF_MASK;
 	bits >>= ALIGN_SELF_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef ALIGN_SELF_INDEX
@@ -109,7 +109,7 @@ static inline uint8_t get_background_attachment_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BACKGROUND_ATTACHMENT_INDEX];
 	bits &= BACKGROUND_ATTACHMENT_MASK;
 	bits >>= BACKGROUND_ATTACHMENT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -120,10 +120,10 @@ static inline uint8_t get_background_attachment(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BACKGROUND_ATTACHMENT_INDEX];
 	bits &= BACKGROUND_ATTACHMENT_MASK;
 	bits >>= BACKGROUND_ATTACHMENT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef BACKGROUND_ATTACHMENT_INDEX
@@ -139,7 +139,7 @@ static inline uint8_t get_background_color_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BACKGROUND_COLOR_INDEX];
 	bits &= BACKGROUND_COLOR_MASK;
 	bits >>= BACKGROUND_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -151,11 +151,11 @@ static inline uint8_t get_background_color(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BACKGROUND_COLOR_INDEX];
 	bits &= BACKGROUND_COLOR_MASK;
 	bits >>= BACKGROUND_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*color = style->i.background_color;
-	
+
 	return type;
 }
 #undef BACKGROUND_COLOR_INDEX
@@ -171,7 +171,7 @@ static inline uint8_t get_background_image_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BACKGROUND_IMAGE_INDEX];
 	bits &= BACKGROUND_IMAGE_MASK;
 	bits >>= BACKGROUND_IMAGE_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -183,11 +183,11 @@ static inline uint8_t get_background_image(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BACKGROUND_IMAGE_INDEX];
 	bits &= BACKGROUND_IMAGE_MASK;
 	bits >>= BACKGROUND_IMAGE_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*string = style->i.background_image;
-	
+
 	return type;
 }
 #undef BACKGROUND_IMAGE_INDEX
@@ -204,7 +204,7 @@ static inline uint8_t get_background_position_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BACKGROUND_POSITION_INDEX];
 	bits &= BACKGROUND_POSITION_MASK;
 	bits >>= BACKGROUND_POSITION_SHIFT;
-	
+
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
 	type = bits & 0x1;
 	return type;
@@ -217,7 +217,7 @@ static inline uint8_t get_background_position(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BACKGROUND_POSITION_INDEX];
 	bits &= BACKGROUND_POSITION_MASK;
 	bits >>= BACKGROUND_POSITION_SHIFT;
-	
+
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
 	type = bits & 0x1;
 	if (type == CSS_BACKGROUND_POSITION_SET) {
@@ -226,7 +226,7 @@ static inline uint8_t get_background_position(const css_computed_style *style,
 		*unit_a = bits >> 6;
 		*unit_b = (bits & 0x3e) >> 1;
 	}
-	
+
 	return type;
 }
 #undef BACKGROUND_POSITION_INDEX
@@ -243,7 +243,7 @@ static inline uint8_t get_background_repeat_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BACKGROUND_REPEAT_INDEX];
 	bits &= BACKGROUND_REPEAT_MASK;
 	bits >>= BACKGROUND_REPEAT_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -254,10 +254,10 @@ static inline uint8_t get_background_repeat(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BACKGROUND_REPEAT_INDEX];
 	bits &= BACKGROUND_REPEAT_MASK;
 	bits >>= BACKGROUND_REPEAT_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef BACKGROUND_REPEAT_INDEX
@@ -274,7 +274,7 @@ static inline uint8_t get_border_bottom_color_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_COLOR_INDEX];
 	bits &= BORDER_BOTTOM_COLOR_MASK;
 	bits >>= BORDER_BOTTOM_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -286,11 +286,11 @@ static inline uint8_t get_border_bottom_color(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_COLOR_INDEX];
 	bits &= BORDER_BOTTOM_COLOR_MASK;
 	bits >>= BORDER_BOTTOM_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*color = style->i.border_bottom_color;
-	
+
 	return type;
 }
 #undef BORDER_BOTTOM_COLOR_INDEX
@@ -307,7 +307,7 @@ static inline uint8_t get_border_bottom_style_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_STYLE_INDEX];
 	bits &= BORDER_BOTTOM_STYLE_MASK;
 	bits >>= BORDER_BOTTOM_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -318,10 +318,10 @@ static inline uint8_t get_border_bottom_style(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_STYLE_INDEX];
 	bits &= BORDER_BOTTOM_STYLE_MASK;
 	bits >>= BORDER_BOTTOM_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef BORDER_BOTTOM_STYLE_INDEX
@@ -338,7 +338,7 @@ static inline uint8_t get_border_bottom_width_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_WIDTH_INDEX];
 	bits &= BORDER_BOTTOM_WIDTH_MASK;
 	bits >>= BORDER_BOTTOM_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	return type;
@@ -350,14 +350,14 @@ static inline uint8_t get_border_bottom_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_WIDTH_INDEX];
 	bits &= BORDER_BOTTOM_WIDTH_MASK;
 	bits >>= BORDER_BOTTOM_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_bottom_width;
 		*unit = bits >> 3;
 	}
-	
+
 	return type;
 }
 #undef BORDER_BOTTOM_WIDTH_INDEX
@@ -373,7 +373,7 @@ static inline uint8_t get_border_collapse_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_COLLAPSE_INDEX];
 	bits &= BORDER_COLLAPSE_MASK;
 	bits >>= BORDER_COLLAPSE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -384,10 +384,10 @@ static inline uint8_t get_border_collapse(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_COLLAPSE_INDEX];
 	bits &= BORDER_COLLAPSE_MASK;
 	bits >>= BORDER_COLLAPSE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef BORDER_COLLAPSE_INDEX
@@ -404,7 +404,7 @@ static inline uint8_t get_border_left_color_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_LEFT_COLOR_INDEX];
 	bits &= BORDER_LEFT_COLOR_MASK;
 	bits >>= BORDER_LEFT_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -416,11 +416,11 @@ static inline uint8_t get_border_left_color(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_LEFT_COLOR_INDEX];
 	bits &= BORDER_LEFT_COLOR_MASK;
 	bits >>= BORDER_LEFT_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*color = style->i.border_left_color;
-	
+
 	return type;
 }
 #undef BORDER_LEFT_COLOR_INDEX
@@ -437,7 +437,7 @@ static inline uint8_t get_border_left_style_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_LEFT_STYLE_INDEX];
 	bits &= BORDER_LEFT_STYLE_MASK;
 	bits >>= BORDER_LEFT_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -448,10 +448,10 @@ static inline uint8_t get_border_left_style(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_LEFT_STYLE_INDEX];
 	bits &= BORDER_LEFT_STYLE_MASK;
 	bits >>= BORDER_LEFT_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef BORDER_LEFT_STYLE_INDEX
@@ -468,7 +468,7 @@ static inline uint8_t get_border_left_width_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_LEFT_WIDTH_INDEX];
 	bits &= BORDER_LEFT_WIDTH_MASK;
 	bits >>= BORDER_LEFT_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	return type;
@@ -480,14 +480,14 @@ static inline uint8_t get_border_left_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_LEFT_WIDTH_INDEX];
 	bits &= BORDER_LEFT_WIDTH_MASK;
 	bits >>= BORDER_LEFT_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_left_width;
 		*unit = bits >> 3;
 	}
-	
+
 	return type;
 }
 #undef BORDER_LEFT_WIDTH_INDEX
@@ -504,7 +504,7 @@ static inline uint8_t get_border_right_color_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_RIGHT_COLOR_INDEX];
 	bits &= BORDER_RIGHT_COLOR_MASK;
 	bits >>= BORDER_RIGHT_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -516,11 +516,11 @@ static inline uint8_t get_border_right_color(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_RIGHT_COLOR_INDEX];
 	bits &= BORDER_RIGHT_COLOR_MASK;
 	bits >>= BORDER_RIGHT_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*color = style->i.border_right_color;
-	
+
 	return type;
 }
 #undef BORDER_RIGHT_COLOR_INDEX
@@ -537,7 +537,7 @@ static inline uint8_t get_border_right_style_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_RIGHT_STYLE_INDEX];
 	bits &= BORDER_RIGHT_STYLE_MASK;
 	bits >>= BORDER_RIGHT_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -548,10 +548,10 @@ static inline uint8_t get_border_right_style(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_RIGHT_STYLE_INDEX];
 	bits &= BORDER_RIGHT_STYLE_MASK;
 	bits >>= BORDER_RIGHT_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef BORDER_RIGHT_STYLE_INDEX
@@ -568,7 +568,7 @@ static inline uint8_t get_border_right_width_bits(const css_computed_style
 	uint32_t bits = style->i.bits[BORDER_RIGHT_WIDTH_INDEX];
 	bits &= BORDER_RIGHT_WIDTH_MASK;
 	bits >>= BORDER_RIGHT_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	return type;
@@ -580,14 +580,14 @@ static inline uint8_t get_border_right_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_RIGHT_WIDTH_INDEX];
 	bits &= BORDER_RIGHT_WIDTH_MASK;
 	bits >>= BORDER_RIGHT_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_right_width;
 		*unit = bits >> 3;
 	}
-	
+
 	return type;
 }
 #undef BORDER_RIGHT_WIDTH_INDEX
@@ -603,7 +603,7 @@ static inline uint8_t get_border_spacing_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_SPACING_INDEX];
 	bits &= BORDER_SPACING_MASK;
 	bits >>= BORDER_SPACING_SHIFT;
-	
+
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
 	type = bits & 0x1;
 	return type;
@@ -616,7 +616,7 @@ static inline uint8_t get_border_spacing(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_SPACING_INDEX];
 	bits &= BORDER_SPACING_MASK;
 	bits >>= BORDER_SPACING_SHIFT;
-	
+
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
 	type = bits & 0x1;
 	if (type == CSS_BORDER_SPACING_SET) {
@@ -625,7 +625,7 @@ static inline uint8_t get_border_spacing(const css_computed_style *style,
 		*unit_a = bits >> 6;
 		*unit_b = (bits & 0x3e) >> 1;
 	}
-	
+
 	return type;
 }
 #undef BORDER_SPACING_INDEX
@@ -641,7 +641,7 @@ static inline uint8_t get_border_top_color_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_TOP_COLOR_INDEX];
 	bits &= BORDER_TOP_COLOR_MASK;
 	bits >>= BORDER_TOP_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -653,11 +653,11 @@ static inline uint8_t get_border_top_color(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_TOP_COLOR_INDEX];
 	bits &= BORDER_TOP_COLOR_MASK;
 	bits >>= BORDER_TOP_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*color = style->i.border_top_color;
-	
+
 	return type;
 }
 #undef BORDER_TOP_COLOR_INDEX
@@ -673,7 +673,7 @@ static inline uint8_t get_border_top_style_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_TOP_STYLE_INDEX];
 	bits &= BORDER_TOP_STYLE_MASK;
 	bits >>= BORDER_TOP_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -684,10 +684,10 @@ static inline uint8_t get_border_top_style(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_TOP_STYLE_INDEX];
 	bits &= BORDER_TOP_STYLE_MASK;
 	bits >>= BORDER_TOP_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef BORDER_TOP_STYLE_INDEX
@@ -703,7 +703,7 @@ static inline uint8_t get_border_top_width_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BORDER_TOP_WIDTH_INDEX];
 	bits &= BORDER_TOP_WIDTH_MASK;
 	bits >>= BORDER_TOP_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	return type;
@@ -715,14 +715,14 @@ static inline uint8_t get_border_top_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[BORDER_TOP_WIDTH_INDEX];
 	bits &= BORDER_TOP_WIDTH_MASK;
 	bits >>= BORDER_TOP_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_top_width;
 		*unit = bits >> 3;
 	}
-	
+
 	return type;
 }
 #undef BORDER_TOP_WIDTH_INDEX
@@ -738,7 +738,7 @@ static inline uint8_t get_bottom_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BOTTOM_INDEX];
 	bits &= BOTTOM_MASK;
 	bits >>= BOTTOM_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -750,14 +750,14 @@ static inline uint8_t get_bottom(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[BOTTOM_INDEX];
 	bits &= BOTTOM_MASK;
 	bits >>= BOTTOM_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_BOTTOM_SET) {
 		*length = style->i.bottom;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef BOTTOM_INDEX
@@ -773,7 +773,7 @@ static inline uint8_t get_box_sizing_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BOX_SIZING_INDEX];
 	bits &= BOX_SIZING_MASK;
 	bits >>= BOX_SIZING_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -784,10 +784,10 @@ static inline uint8_t get_box_sizing(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BOX_SIZING_INDEX];
 	bits &= BOX_SIZING_MASK;
 	bits >>= BOX_SIZING_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef BOX_SIZING_INDEX
@@ -803,7 +803,7 @@ static inline uint8_t get_break_after_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BREAK_AFTER_INDEX];
 	bits &= BREAK_AFTER_MASK;
 	bits >>= BREAK_AFTER_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -814,10 +814,10 @@ static inline uint8_t get_break_after(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BREAK_AFTER_INDEX];
 	bits &= BREAK_AFTER_MASK;
 	bits >>= BREAK_AFTER_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef BREAK_AFTER_INDEX
@@ -833,7 +833,7 @@ static inline uint8_t get_break_before_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BREAK_BEFORE_INDEX];
 	bits &= BREAK_BEFORE_MASK;
 	bits >>= BREAK_BEFORE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -844,10 +844,10 @@ static inline uint8_t get_break_before(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BREAK_BEFORE_INDEX];
 	bits &= BREAK_BEFORE_MASK;
 	bits >>= BREAK_BEFORE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef BREAK_BEFORE_INDEX
@@ -863,7 +863,7 @@ static inline uint8_t get_break_inside_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BREAK_INSIDE_INDEX];
 	bits &= BREAK_INSIDE_MASK;
 	bits >>= BREAK_INSIDE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -874,10 +874,10 @@ static inline uint8_t get_break_inside(const css_computed_style *style)
 	uint32_t bits = style->i.bits[BREAK_INSIDE_INDEX];
 	bits &= BREAK_INSIDE_MASK;
 	bits >>= BREAK_INSIDE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef BREAK_INSIDE_INDEX
@@ -893,7 +893,7 @@ static inline uint8_t get_caption_side_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[CAPTION_SIDE_INDEX];
 	bits &= CAPTION_SIDE_MASK;
 	bits >>= CAPTION_SIDE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -904,10 +904,10 @@ static inline uint8_t get_caption_side(const css_computed_style *style)
 	uint32_t bits = style->i.bits[CAPTION_SIDE_INDEX];
 	bits &= CAPTION_SIDE_MASK;
 	bits >>= CAPTION_SIDE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef CAPTION_SIDE_INDEX
@@ -923,7 +923,7 @@ static inline uint8_t get_clear_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[CLEAR_INDEX];
 	bits &= CLEAR_MASK;
 	bits >>= CLEAR_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -934,10 +934,10 @@ static inline uint8_t get_clear(const css_computed_style *style)
 	uint32_t bits = style->i.bits[CLEAR_INDEX];
 	bits &= CLEAR_MASK;
 	bits >>= CLEAR_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef CLEAR_INDEX
@@ -953,7 +953,7 @@ static inline uint8_t get_clip_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[CLIP_INDEX];
 	bits &= CLIP_MASK;
 	bits >>= CLIP_SHIFT;
-	
+
 	/* 26bits: aaaaabbbbbcccccdddddtttttt : unit_a | unit_b | unit_c |
 			unit_d | type */
 	type = bits & 0x3f;
@@ -1007,7 +1007,7 @@ static inline uint8_t get_color_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLOR_INDEX];
 	bits &= COLOR_MASK;
 	bits >>= COLOR_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -1019,11 +1019,11 @@ static inline uint8_t get_color(const css_computed_style *style, css_color
 	uint32_t bits = style->i.bits[COLOR_INDEX];
 	bits &= COLOR_MASK;
 	bits >>= COLOR_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*color = style->i.color;
-	
+
 	return type;
 }
 #undef COLOR_INDEX
@@ -1039,7 +1039,7 @@ static inline uint8_t get_column_count_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_COUNT_INDEX];
 	bits &= COLUMN_COUNT_MASK;
 	bits >>= COLUMN_COUNT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1051,11 +1051,11 @@ static inline uint8_t get_column_count(const css_computed_style *style, int32_t
 	uint32_t bits = style->i.bits[COLUMN_COUNT_INDEX];
 	bits &= COLUMN_COUNT_MASK;
 	bits >>= COLUMN_COUNT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*integer = style->i.column_count;
-	
+
 	return type;
 }
 #undef COLUMN_COUNT_INDEX
@@ -1071,7 +1071,7 @@ static inline uint8_t get_column_fill_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_FILL_INDEX];
 	bits &= COLUMN_FILL_MASK;
 	bits >>= COLUMN_FILL_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1082,10 +1082,10 @@ static inline uint8_t get_column_fill(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_FILL_INDEX];
 	bits &= COLUMN_FILL_MASK;
 	bits >>= COLUMN_FILL_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef COLUMN_FILL_INDEX
@@ -1101,7 +1101,7 @@ static inline uint8_t get_column_gap_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_GAP_INDEX];
 	bits &= COLUMN_GAP_MASK;
 	bits >>= COLUMN_GAP_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -1113,14 +1113,14 @@ static inline uint8_t get_column_gap(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[COLUMN_GAP_INDEX];
 	bits &= COLUMN_GAP_MASK;
 	bits >>= COLUMN_GAP_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_COLUMN_GAP_SET) {
 		*length = style->i.column_gap;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef COLUMN_GAP_INDEX
@@ -1137,7 +1137,7 @@ static inline uint8_t get_column_rule_color_bits(const css_computed_style
 	uint32_t bits = style->i.bits[COLUMN_RULE_COLOR_INDEX];
 	bits &= COLUMN_RULE_COLOR_MASK;
 	bits >>= COLUMN_RULE_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1149,11 +1149,11 @@ static inline uint8_t get_column_rule_color(const css_computed_style *style,
 	uint32_t bits = style->i.bits[COLUMN_RULE_COLOR_INDEX];
 	bits &= COLUMN_RULE_COLOR_MASK;
 	bits >>= COLUMN_RULE_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*color = style->i.column_rule_color;
-	
+
 	return type;
 }
 #undef COLUMN_RULE_COLOR_INDEX
@@ -1170,7 +1170,7 @@ static inline uint8_t get_column_rule_style_bits(const css_computed_style
 	uint32_t bits = style->i.bits[COLUMN_RULE_STYLE_INDEX];
 	bits &= COLUMN_RULE_STYLE_MASK;
 	bits >>= COLUMN_RULE_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -1181,10 +1181,10 @@ static inline uint8_t get_column_rule_style(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_RULE_STYLE_INDEX];
 	bits &= COLUMN_RULE_STYLE_MASK;
 	bits >>= COLUMN_RULE_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef COLUMN_RULE_STYLE_INDEX
@@ -1201,7 +1201,7 @@ static inline uint8_t get_column_rule_width_bits(const css_computed_style
 	uint32_t bits = style->i.bits[COLUMN_RULE_WIDTH_INDEX];
 	bits &= COLUMN_RULE_WIDTH_MASK;
 	bits >>= COLUMN_RULE_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	return type;
@@ -1213,14 +1213,14 @@ static inline uint8_t get_column_rule_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[COLUMN_RULE_WIDTH_INDEX];
 	bits &= COLUMN_RULE_WIDTH_MASK;
 	bits >>= COLUMN_RULE_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	if (type == CSS_COLUMN_RULE_WIDTH_WIDTH) {
 		*length = style->i.column_rule_width;
 		*unit = bits >> 3;
 	}
-	
+
 	return type;
 }
 #undef COLUMN_RULE_WIDTH_INDEX
@@ -1236,7 +1236,7 @@ static inline uint8_t get_column_span_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_SPAN_INDEX];
 	bits &= COLUMN_SPAN_MASK;
 	bits >>= COLUMN_SPAN_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1247,10 +1247,10 @@ static inline uint8_t get_column_span(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_SPAN_INDEX];
 	bits &= COLUMN_SPAN_MASK;
 	bits >>= COLUMN_SPAN_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef COLUMN_SPAN_INDEX
@@ -1266,7 +1266,7 @@ static inline uint8_t get_column_width_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COLUMN_WIDTH_INDEX];
 	bits &= COLUMN_WIDTH_MASK;
 	bits >>= COLUMN_WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -1278,14 +1278,14 @@ static inline uint8_t get_column_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[COLUMN_WIDTH_INDEX];
 	bits &= COLUMN_WIDTH_MASK;
 	bits >>= COLUMN_WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_COLUMN_WIDTH_SET) {
 		*length = style->i.column_width;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef COLUMN_WIDTH_INDEX
@@ -1301,7 +1301,7 @@ static inline uint8_t get_content_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[CONTENT_INDEX];
 	bits &= CONTENT_MASK;
 	bits >>= CONTENT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1313,13 +1313,13 @@ static inline uint8_t get_content(const css_computed_style *style, const
 	uint32_t bits = style->i.bits[CONTENT_INDEX];
 	bits &= CONTENT_MASK;
 	bits >>= CONTENT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	if (type == CSS_CONTENT_SET) {
 		*content_item = style->content;
 	}
-	
+
 	return type;
 }
 #undef CONTENT_INDEX
@@ -1336,7 +1336,7 @@ static inline uint8_t get_counter_increment_bits(const css_computed_style
 	uint32_t bits = style->i.bits[COUNTER_INCREMENT_INDEX];
 	bits &= COUNTER_INCREMENT_MASK;
 	bits >>= COUNTER_INCREMENT_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -1348,11 +1348,11 @@ static inline uint8_t get_counter_increment(const css_computed_style *style,
 	uint32_t bits = style->i.bits[COUNTER_INCREMENT_INDEX];
 	bits &= COUNTER_INCREMENT_MASK;
 	bits >>= COUNTER_INCREMENT_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*counter_arr = style->counter_increment;
-	
+
 	return type;
 }
 #undef COUNTER_INCREMENT_INDEX
@@ -1368,7 +1368,7 @@ static inline uint8_t get_counter_reset_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[COUNTER_RESET_INDEX];
 	bits &= COUNTER_RESET_MASK;
 	bits >>= COUNTER_RESET_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -1380,11 +1380,11 @@ static inline uint8_t get_counter_reset(const css_computed_style *style, const
 	uint32_t bits = style->i.bits[COUNTER_RESET_INDEX];
 	bits &= COUNTER_RESET_MASK;
 	bits >>= COUNTER_RESET_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*counter_arr = style->counter_reset;
-	
+
 	return type;
 }
 #undef COUNTER_RESET_INDEX
@@ -1400,7 +1400,7 @@ static inline uint8_t get_cursor_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[CURSOR_INDEX];
 	bits &= CURSOR_MASK;
 	bits >>= CURSOR_SHIFT;
-	
+
 	/* 5bits: ttttt : type */
 	type = bits & 0x1f;
 	return type;
@@ -1412,11 +1412,11 @@ static inline uint8_t get_cursor(const css_computed_style *style, lwc_string
 	uint32_t bits = style->i.bits[CURSOR_INDEX];
 	bits &= CURSOR_MASK;
 	bits >>= CURSOR_SHIFT;
-	
+
 	/* 5bits: ttttt : type */
 	type = bits & 0x1f;
 	*string_arr = style->cursor;
-	
+
 	return type;
 }
 #undef CURSOR_INDEX
@@ -1432,7 +1432,7 @@ static inline uint8_t get_direction_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[DIRECTION_INDEX];
 	bits &= DIRECTION_MASK;
 	bits >>= DIRECTION_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1443,10 +1443,10 @@ static inline uint8_t get_direction(const css_computed_style *style)
 	uint32_t bits = style->i.bits[DIRECTION_INDEX];
 	bits &= DIRECTION_MASK;
 	bits >>= DIRECTION_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef DIRECTION_INDEX
@@ -1462,7 +1462,7 @@ static inline uint8_t get_display_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[DISPLAY_INDEX];
 	bits &= DISPLAY_MASK;
 	bits >>= DISPLAY_SHIFT;
-	
+
 	/* 5bits: ttttt : type */
 	type = bits & 0x1f;
 	return type;
@@ -1473,10 +1473,10 @@ static inline uint8_t get_display(const css_computed_style *style)
 	uint32_t bits = style->i.bits[DISPLAY_INDEX];
 	bits &= DISPLAY_MASK;
 	bits >>= DISPLAY_SHIFT;
-	
+
 	/* 5bits: ttttt : type */
 	type = bits & 0x1f;
-	
+
 	return type;
 }
 #undef DISPLAY_INDEX
@@ -1492,7 +1492,7 @@ static inline uint8_t get_empty_cells_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[EMPTY_CELLS_INDEX];
 	bits &= EMPTY_CELLS_MASK;
 	bits >>= EMPTY_CELLS_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1503,10 +1503,10 @@ static inline uint8_t get_empty_cells(const css_computed_style *style)
 	uint32_t bits = style->i.bits[EMPTY_CELLS_INDEX];
 	bits &= EMPTY_CELLS_MASK;
 	bits >>= EMPTY_CELLS_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef EMPTY_CELLS_INDEX
@@ -1522,7 +1522,7 @@ static inline uint8_t get_fill_opacity_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FILL_OPACITY_INDEX];
 	bits &= FILL_OPACITY_MASK;
 	bits >>= FILL_OPACITY_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -1534,13 +1534,13 @@ static inline uint8_t get_fill_opacity(const css_computed_style *style,
 	uint32_t bits = style->i.bits[FILL_OPACITY_INDEX];
 	bits &= FILL_OPACITY_MASK;
 	bits >>= FILL_OPACITY_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	if (type == CSS_FILL_OPACITY_SET) {
 		*fixed = style->i.fill_opacity;
 	}
-	
+
 	return type;
 }
 #undef FILL_OPACITY_INDEX
@@ -1556,7 +1556,7 @@ static inline uint8_t get_flex_basis_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLEX_BASIS_INDEX];
 	bits &= FLEX_BASIS_MASK;
 	bits >>= FLEX_BASIS_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -1568,14 +1568,14 @@ static inline uint8_t get_flex_basis(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[FLEX_BASIS_INDEX];
 	bits &= FLEX_BASIS_MASK;
 	bits >>= FLEX_BASIS_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_FLEX_BASIS_SET) {
 		*length = style->i.flex_basis;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef FLEX_BASIS_INDEX
@@ -1591,7 +1591,7 @@ static inline uint8_t get_flex_direction_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLEX_DIRECTION_INDEX];
 	bits &= FLEX_DIRECTION_MASK;
 	bits >>= FLEX_DIRECTION_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -1602,10 +1602,10 @@ static inline uint8_t get_flex_direction(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLEX_DIRECTION_INDEX];
 	bits &= FLEX_DIRECTION_MASK;
 	bits >>= FLEX_DIRECTION_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef FLEX_DIRECTION_INDEX
@@ -1621,7 +1621,7 @@ static inline uint8_t get_flex_grow_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLEX_GROW_INDEX];
 	bits &= FLEX_GROW_MASK;
 	bits >>= FLEX_GROW_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -1633,13 +1633,13 @@ static inline uint8_t get_flex_grow(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[FLEX_GROW_INDEX];
 	bits &= FLEX_GROW_MASK;
 	bits >>= FLEX_GROW_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	if (type == CSS_FLEX_GROW_SET) {
 		*fixed = style->i.flex_grow;
 	}
-	
+
 	return type;
 }
 #undef FLEX_GROW_INDEX
@@ -1655,7 +1655,7 @@ static inline uint8_t get_flex_shrink_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLEX_SHRINK_INDEX];
 	bits &= FLEX_SHRINK_MASK;
 	bits >>= FLEX_SHRINK_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -1667,13 +1667,13 @@ static inline uint8_t get_flex_shrink(const css_computed_style *style,
 	uint32_t bits = style->i.bits[FLEX_SHRINK_INDEX];
 	bits &= FLEX_SHRINK_MASK;
 	bits >>= FLEX_SHRINK_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	if (type == CSS_FLEX_SHRINK_SET) {
 		*fixed = style->i.flex_shrink;
 	}
-	
+
 	return type;
 }
 #undef FLEX_SHRINK_INDEX
@@ -1689,7 +1689,7 @@ static inline uint8_t get_flex_wrap_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLEX_WRAP_INDEX];
 	bits &= FLEX_WRAP_MASK;
 	bits >>= FLEX_WRAP_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1700,10 +1700,10 @@ static inline uint8_t get_flex_wrap(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLEX_WRAP_INDEX];
 	bits &= FLEX_WRAP_MASK;
 	bits >>= FLEX_WRAP_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef FLEX_WRAP_INDEX
@@ -1719,7 +1719,7 @@ static inline uint8_t get_float_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLOAT_INDEX];
 	bits &= FLOAT_MASK;
 	bits >>= FLOAT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1730,10 +1730,10 @@ static inline uint8_t get_float(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FLOAT_INDEX];
 	bits &= FLOAT_MASK;
 	bits >>= FLOAT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef FLOAT_INDEX
@@ -1749,7 +1749,7 @@ static inline uint8_t get_font_family_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_FAMILY_INDEX];
 	bits &= FONT_FAMILY_MASK;
 	bits >>= FONT_FAMILY_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -1761,11 +1761,11 @@ static inline uint8_t get_font_family(const css_computed_style *style,
 	uint32_t bits = style->i.bits[FONT_FAMILY_INDEX];
 	bits &= FONT_FAMILY_MASK;
 	bits >>= FONT_FAMILY_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	*string_arr = style->font_family;
-	
+
 	return type;
 }
 #undef FONT_FAMILY_INDEX
@@ -1781,7 +1781,7 @@ static inline uint8_t get_font_size_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_SIZE_INDEX];
 	bits &= FONT_SIZE_MASK;
 	bits >>= FONT_SIZE_SHIFT;
-	
+
 	/* 9bits: uuuuutttt : unit | type */
 	type = bits & 0xf;
 	return type;
@@ -1793,14 +1793,14 @@ static inline uint8_t get_font_size(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[FONT_SIZE_INDEX];
 	bits &= FONT_SIZE_MASK;
 	bits >>= FONT_SIZE_SHIFT;
-	
+
 	/* 9bits: uuuuutttt : unit | type */
 	type = bits & 0xf;
 	if (type == CSS_FONT_SIZE_DIMENSION) {
 		*length = style->i.font_size;
 		*unit = bits >> 4;
 	}
-	
+
 	return type;
 }
 #undef FONT_SIZE_INDEX
@@ -1816,7 +1816,7 @@ static inline uint8_t get_font_style_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_STYLE_INDEX];
 	bits &= FONT_STYLE_MASK;
 	bits >>= FONT_STYLE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1827,10 +1827,10 @@ static inline uint8_t get_font_style(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_STYLE_INDEX];
 	bits &= FONT_STYLE_MASK;
 	bits >>= FONT_STYLE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef FONT_STYLE_INDEX
@@ -1846,7 +1846,7 @@ static inline uint8_t get_font_variant_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_VARIANT_INDEX];
 	bits &= FONT_VARIANT_MASK;
 	bits >>= FONT_VARIANT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -1857,10 +1857,10 @@ static inline uint8_t get_font_variant(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_VARIANT_INDEX];
 	bits &= FONT_VARIANT_MASK;
 	bits >>= FONT_VARIANT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef FONT_VARIANT_INDEX
@@ -1876,7 +1876,7 @@ static inline uint8_t get_font_weight_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_WEIGHT_INDEX];
 	bits &= FONT_WEIGHT_MASK;
 	bits >>= FONT_WEIGHT_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -1887,10 +1887,10 @@ static inline uint8_t get_font_weight(const css_computed_style *style)
 	uint32_t bits = style->i.bits[FONT_WEIGHT_INDEX];
 	bits &= FONT_WEIGHT_MASK;
 	bits >>= FONT_WEIGHT_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef FONT_WEIGHT_INDEX
@@ -1906,7 +1906,7 @@ static inline uint8_t get_height_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[HEIGHT_INDEX];
 	bits &= HEIGHT_MASK;
 	bits >>= HEIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -1918,14 +1918,14 @@ static inline uint8_t get_height(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[HEIGHT_INDEX];
 	bits &= HEIGHT_MASK;
 	bits >>= HEIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_HEIGHT_SET) {
 		*length = style->i.height;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef HEIGHT_INDEX
@@ -1941,7 +1941,7 @@ static inline uint8_t get_justify_content_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[JUSTIFY_CONTENT_INDEX];
 	bits &= JUSTIFY_CONTENT_MASK;
 	bits >>= JUSTIFY_CONTENT_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -1952,10 +1952,10 @@ static inline uint8_t get_justify_content(const css_computed_style *style)
 	uint32_t bits = style->i.bits[JUSTIFY_CONTENT_INDEX];
 	bits &= JUSTIFY_CONTENT_MASK;
 	bits >>= JUSTIFY_CONTENT_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef JUSTIFY_CONTENT_INDEX
@@ -1971,7 +1971,7 @@ static inline uint8_t get_left_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[LEFT_INDEX];
 	bits &= LEFT_MASK;
 	bits >>= LEFT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -1983,14 +1983,14 @@ static inline uint8_t get_left(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[LEFT_INDEX];
 	bits &= LEFT_MASK;
 	bits >>= LEFT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_LEFT_SET) {
 		*length = style->i.left;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef LEFT_INDEX
@@ -2006,7 +2006,7 @@ static inline uint8_t get_letter_spacing_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[LETTER_SPACING_INDEX];
 	bits &= LETTER_SPACING_MASK;
 	bits >>= LETTER_SPACING_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2018,14 +2018,14 @@ static inline uint8_t get_letter_spacing(const css_computed_style *style,
 	uint32_t bits = style->i.bits[LETTER_SPACING_INDEX];
 	bits &= LETTER_SPACING_MASK;
 	bits >>= LETTER_SPACING_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_LETTER_SPACING_SET) {
 		*length = style->i.letter_spacing;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef LETTER_SPACING_INDEX
@@ -2041,7 +2041,7 @@ static inline uint8_t get_line_height_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[LINE_HEIGHT_INDEX];
 	bits &= LINE_HEIGHT_MASK;
 	bits >>= LINE_HEIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2079,7 +2079,7 @@ static inline uint8_t get_list_style_image_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[LIST_STYLE_IMAGE_INDEX];
 	bits &= LIST_STYLE_IMAGE_MASK;
 	bits >>= LIST_STYLE_IMAGE_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -2091,11 +2091,11 @@ static inline uint8_t get_list_style_image(const css_computed_style *style,
 	uint32_t bits = style->i.bits[LIST_STYLE_IMAGE_INDEX];
 	bits &= LIST_STYLE_IMAGE_MASK;
 	bits >>= LIST_STYLE_IMAGE_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*string = style->i.list_style_image;
-	
+
 	return type;
 }
 #undef LIST_STYLE_IMAGE_INDEX
@@ -2112,7 +2112,7 @@ static inline uint8_t get_list_style_position_bits(const css_computed_style
 	uint32_t bits = style->i.bits[LIST_STYLE_POSITION_INDEX];
 	bits &= LIST_STYLE_POSITION_MASK;
 	bits >>= LIST_STYLE_POSITION_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -2123,10 +2123,10 @@ static inline uint8_t get_list_style_position(const css_computed_style *style)
 	uint32_t bits = style->i.bits[LIST_STYLE_POSITION_INDEX];
 	bits &= LIST_STYLE_POSITION_MASK;
 	bits >>= LIST_STYLE_POSITION_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef LIST_STYLE_POSITION_INDEX
@@ -2142,7 +2142,7 @@ static inline uint8_t get_list_style_type_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[LIST_STYLE_TYPE_INDEX];
 	bits &= LIST_STYLE_TYPE_MASK;
 	bits >>= LIST_STYLE_TYPE_SHIFT;
-	
+
 	/* 6bits: tttttt : type */
 	type = bits & 0x3f;
 	return type;
@@ -2153,10 +2153,10 @@ static inline uint8_t get_list_style_type(const css_computed_style *style)
 	uint32_t bits = style->i.bits[LIST_STYLE_TYPE_INDEX];
 	bits &= LIST_STYLE_TYPE_MASK;
 	bits >>= LIST_STYLE_TYPE_SHIFT;
-	
+
 	/* 6bits: tttttt : type */
 	type = bits & 0x3f;
-	
+
 	return type;
 }
 #undef LIST_STYLE_TYPE_INDEX
@@ -2172,7 +2172,7 @@ static inline uint8_t get_margin_bottom_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MARGIN_BOTTOM_INDEX];
 	bits &= MARGIN_BOTTOM_MASK;
 	bits >>= MARGIN_BOTTOM_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2184,14 +2184,14 @@ static inline uint8_t get_margin_bottom(const css_computed_style *style,
 	uint32_t bits = style->i.bits[MARGIN_BOTTOM_INDEX];
 	bits &= MARGIN_BOTTOM_MASK;
 	bits >>= MARGIN_BOTTOM_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_bottom;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MARGIN_BOTTOM_INDEX
@@ -2207,7 +2207,7 @@ static inline uint8_t get_margin_left_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MARGIN_LEFT_INDEX];
 	bits &= MARGIN_LEFT_MASK;
 	bits >>= MARGIN_LEFT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2219,14 +2219,14 @@ static inline uint8_t get_margin_left(const css_computed_style *style,
 	uint32_t bits = style->i.bits[MARGIN_LEFT_INDEX];
 	bits &= MARGIN_LEFT_MASK;
 	bits >>= MARGIN_LEFT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_left;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MARGIN_LEFT_INDEX
@@ -2242,7 +2242,7 @@ static inline uint8_t get_margin_right_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MARGIN_RIGHT_INDEX];
 	bits &= MARGIN_RIGHT_MASK;
 	bits >>= MARGIN_RIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2254,14 +2254,14 @@ static inline uint8_t get_margin_right(const css_computed_style *style,
 	uint32_t bits = style->i.bits[MARGIN_RIGHT_INDEX];
 	bits &= MARGIN_RIGHT_MASK;
 	bits >>= MARGIN_RIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_right;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MARGIN_RIGHT_INDEX
@@ -2277,7 +2277,7 @@ static inline uint8_t get_margin_top_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MARGIN_TOP_INDEX];
 	bits &= MARGIN_TOP_MASK;
 	bits >>= MARGIN_TOP_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2289,14 +2289,14 @@ static inline uint8_t get_margin_top(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[MARGIN_TOP_INDEX];
 	bits &= MARGIN_TOP_MASK;
 	bits >>= MARGIN_TOP_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_top;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MARGIN_TOP_INDEX
@@ -2312,7 +2312,7 @@ static inline uint8_t get_max_height_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MAX_HEIGHT_INDEX];
 	bits &= MAX_HEIGHT_MASK;
 	bits >>= MAX_HEIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2324,14 +2324,14 @@ static inline uint8_t get_max_height(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[MAX_HEIGHT_INDEX];
 	bits &= MAX_HEIGHT_MASK;
 	bits >>= MAX_HEIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MAX_HEIGHT_SET) {
 		*length = style->i.max_height;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MAX_HEIGHT_INDEX
@@ -2347,7 +2347,7 @@ static inline uint8_t get_max_width_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MAX_WIDTH_INDEX];
 	bits &= MAX_WIDTH_MASK;
 	bits >>= MAX_WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2359,14 +2359,14 @@ static inline uint8_t get_max_width(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[MAX_WIDTH_INDEX];
 	bits &= MAX_WIDTH_MASK;
 	bits >>= MAX_WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MAX_WIDTH_SET) {
 		*length = style->i.max_width;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MAX_WIDTH_INDEX
@@ -2382,7 +2382,7 @@ static inline uint8_t get_min_height_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MIN_HEIGHT_INDEX];
 	bits &= MIN_HEIGHT_MASK;
 	bits >>= MIN_HEIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2394,14 +2394,14 @@ static inline uint8_t get_min_height(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[MIN_HEIGHT_INDEX];
 	bits &= MIN_HEIGHT_MASK;
 	bits >>= MIN_HEIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MIN_HEIGHT_SET) {
 		*length = style->i.min_height;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MIN_HEIGHT_INDEX
@@ -2417,7 +2417,7 @@ static inline uint8_t get_min_width_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[MIN_WIDTH_INDEX];
 	bits &= MIN_WIDTH_MASK;
 	bits >>= MIN_WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -2429,14 +2429,14 @@ static inline uint8_t get_min_width(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[MIN_WIDTH_INDEX];
 	bits &= MIN_WIDTH_MASK;
 	bits >>= MIN_WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_MIN_WIDTH_SET) {
 		*length = style->i.min_width;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef MIN_WIDTH_INDEX
@@ -2452,7 +2452,7 @@ static inline uint8_t get_opacity_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OPACITY_INDEX];
 	bits &= OPACITY_MASK;
 	bits >>= OPACITY_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -2464,13 +2464,13 @@ static inline uint8_t get_opacity(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[OPACITY_INDEX];
 	bits &= OPACITY_MASK;
 	bits >>= OPACITY_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	if (type == CSS_OPACITY_SET) {
 		*fixed = style->i.opacity;
 	}
-	
+
 	return type;
 }
 #undef OPACITY_INDEX
@@ -2486,7 +2486,7 @@ static inline uint8_t get_order_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ORDER_INDEX];
 	bits &= ORDER_MASK;
 	bits >>= ORDER_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -2498,13 +2498,13 @@ static inline uint8_t get_order(const css_computed_style *style, int32_t
 	uint32_t bits = style->i.bits[ORDER_INDEX];
 	bits &= ORDER_MASK;
 	bits >>= ORDER_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	if (type == CSS_ORDER_SET) {
 		*integer = style->i.order;
 	}
-	
+
 	return type;
 }
 #undef ORDER_INDEX
@@ -2520,7 +2520,7 @@ static inline uint8_t get_orphans_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[ORPHANS_INDEX];
 	bits &= ORPHANS_MASK;
 	bits >>= ORPHANS_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -2532,11 +2532,11 @@ static inline uint8_t get_orphans(const css_computed_style *style, int32_t
 	uint32_t bits = style->i.bits[ORPHANS_INDEX];
 	bits &= ORPHANS_MASK;
 	bits >>= ORPHANS_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*integer = style->i.orphans;
-	
+
 	return type;
 }
 #undef ORPHANS_INDEX
@@ -2552,7 +2552,7 @@ static inline uint8_t get_outline_color_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OUTLINE_COLOR_INDEX];
 	bits &= OUTLINE_COLOR_MASK;
 	bits >>= OUTLINE_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -2564,13 +2564,13 @@ static inline uint8_t get_outline_color(const css_computed_style *style,
 	uint32_t bits = style->i.bits[OUTLINE_COLOR_INDEX];
 	bits &= OUTLINE_COLOR_MASK;
 	bits >>= OUTLINE_COLOR_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	if (type == CSS_OUTLINE_COLOR_COLOR) {
 		*color = style->i.outline_color;
 	}
-	
+
 	return type;
 }
 #undef OUTLINE_COLOR_INDEX
@@ -2586,7 +2586,7 @@ static inline uint8_t get_outline_style_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OUTLINE_STYLE_INDEX];
 	bits &= OUTLINE_STYLE_MASK;
 	bits >>= OUTLINE_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -2597,10 +2597,10 @@ static inline uint8_t get_outline_style(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OUTLINE_STYLE_INDEX];
 	bits &= OUTLINE_STYLE_MASK;
 	bits >>= OUTLINE_STYLE_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef OUTLINE_STYLE_INDEX
@@ -2616,7 +2616,7 @@ static inline uint8_t get_outline_width_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OUTLINE_WIDTH_INDEX];
 	bits &= OUTLINE_WIDTH_MASK;
 	bits >>= OUTLINE_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	return type;
@@ -2628,14 +2628,14 @@ static inline uint8_t get_outline_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[OUTLINE_WIDTH_INDEX];
 	bits &= OUTLINE_WIDTH_MASK;
 	bits >>= OUTLINE_WIDTH_SHIFT;
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	type = bits & 0x7;
 	if (type == CSS_OUTLINE_WIDTH_WIDTH) {
 		*length = style->i.outline_width;
 		*unit = bits >> 3;
 	}
-	
+
 	return type;
 }
 #undef OUTLINE_WIDTH_INDEX
@@ -2651,7 +2651,7 @@ static inline uint8_t get_overflow_x_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OVERFLOW_X_INDEX];
 	bits &= OVERFLOW_X_MASK;
 	bits >>= OVERFLOW_X_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -2662,10 +2662,10 @@ static inline uint8_t get_overflow_x(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OVERFLOW_X_INDEX];
 	bits &= OVERFLOW_X_MASK;
 	bits >>= OVERFLOW_X_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef OVERFLOW_X_INDEX
@@ -2681,7 +2681,7 @@ static inline uint8_t get_overflow_y_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OVERFLOW_Y_INDEX];
 	bits &= OVERFLOW_Y_MASK;
 	bits >>= OVERFLOW_Y_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -2692,10 +2692,10 @@ static inline uint8_t get_overflow_y(const css_computed_style *style)
 	uint32_t bits = style->i.bits[OVERFLOW_Y_INDEX];
 	bits &= OVERFLOW_Y_MASK;
 	bits >>= OVERFLOW_Y_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef OVERFLOW_Y_INDEX
@@ -2711,7 +2711,7 @@ static inline uint8_t get_padding_bottom_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PADDING_BOTTOM_INDEX];
 	bits &= PADDING_BOTTOM_MASK;
 	bits >>= PADDING_BOTTOM_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	return type;
@@ -2723,14 +2723,14 @@ static inline uint8_t get_padding_bottom(const css_computed_style *style,
 	uint32_t bits = style->i.bits[PADDING_BOTTOM_INDEX];
 	bits &= PADDING_BOTTOM_MASK;
 	bits >>= PADDING_BOTTOM_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_bottom;
 		*unit = bits >> 1;
 	}
-	
+
 	return type;
 }
 #undef PADDING_BOTTOM_INDEX
@@ -2746,7 +2746,7 @@ static inline uint8_t get_padding_left_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PADDING_LEFT_INDEX];
 	bits &= PADDING_LEFT_MASK;
 	bits >>= PADDING_LEFT_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	return type;
@@ -2758,14 +2758,14 @@ static inline uint8_t get_padding_left(const css_computed_style *style,
 	uint32_t bits = style->i.bits[PADDING_LEFT_INDEX];
 	bits &= PADDING_LEFT_MASK;
 	bits >>= PADDING_LEFT_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_left;
 		*unit = bits >> 1;
 	}
-	
+
 	return type;
 }
 #undef PADDING_LEFT_INDEX
@@ -2781,7 +2781,7 @@ static inline uint8_t get_padding_right_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PADDING_RIGHT_INDEX];
 	bits &= PADDING_RIGHT_MASK;
 	bits >>= PADDING_RIGHT_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	return type;
@@ -2793,14 +2793,14 @@ static inline uint8_t get_padding_right(const css_computed_style *style,
 	uint32_t bits = style->i.bits[PADDING_RIGHT_INDEX];
 	bits &= PADDING_RIGHT_MASK;
 	bits >>= PADDING_RIGHT_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_right;
 		*unit = bits >> 1;
 	}
-	
+
 	return type;
 }
 #undef PADDING_RIGHT_INDEX
@@ -2816,7 +2816,7 @@ static inline uint8_t get_padding_top_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PADDING_TOP_INDEX];
 	bits &= PADDING_TOP_MASK;
 	bits >>= PADDING_TOP_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	return type;
@@ -2828,14 +2828,14 @@ static inline uint8_t get_padding_top(const css_computed_style *style,
 	uint32_t bits = style->i.bits[PADDING_TOP_INDEX];
 	bits &= PADDING_TOP_MASK;
 	bits >>= PADDING_TOP_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_top;
 		*unit = bits >> 1;
 	}
-	
+
 	return type;
 }
 #undef PADDING_TOP_INDEX
@@ -2851,7 +2851,7 @@ static inline uint8_t get_page_break_after_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PAGE_BREAK_AFTER_INDEX];
 	bits &= PAGE_BREAK_AFTER_MASK;
 	bits >>= PAGE_BREAK_AFTER_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -2862,10 +2862,10 @@ static inline uint8_t get_page_break_after(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PAGE_BREAK_AFTER_INDEX];
 	bits &= PAGE_BREAK_AFTER_MASK;
 	bits >>= PAGE_BREAK_AFTER_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef PAGE_BREAK_AFTER_INDEX
@@ -2882,7 +2882,7 @@ static inline uint8_t get_page_break_before_bits(const css_computed_style
 	uint32_t bits = style->i.bits[PAGE_BREAK_BEFORE_INDEX];
 	bits &= PAGE_BREAK_BEFORE_MASK;
 	bits >>= PAGE_BREAK_BEFORE_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -2893,10 +2893,10 @@ static inline uint8_t get_page_break_before(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PAGE_BREAK_BEFORE_INDEX];
 	bits &= PAGE_BREAK_BEFORE_MASK;
 	bits >>= PAGE_BREAK_BEFORE_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef PAGE_BREAK_BEFORE_INDEX
@@ -2913,7 +2913,7 @@ static inline uint8_t get_page_break_inside_bits(const css_computed_style
 	uint32_t bits = style->i.bits[PAGE_BREAK_INSIDE_INDEX];
 	bits &= PAGE_BREAK_INSIDE_MASK;
 	bits >>= PAGE_BREAK_INSIDE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -2924,10 +2924,10 @@ static inline uint8_t get_page_break_inside(const css_computed_style *style)
 	uint32_t bits = style->i.bits[PAGE_BREAK_INSIDE_INDEX];
 	bits &= PAGE_BREAK_INSIDE_MASK;
 	bits >>= PAGE_BREAK_INSIDE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef PAGE_BREAK_INSIDE_INDEX
@@ -2943,7 +2943,7 @@ static inline uint8_t get_position_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[POSITION_INDEX];
 	bits &= POSITION_MASK;
 	bits >>= POSITION_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -2954,10 +2954,10 @@ static inline uint8_t get_position(const css_computed_style *style)
 	uint32_t bits = style->i.bits[POSITION_INDEX];
 	bits &= POSITION_MASK;
 	bits >>= POSITION_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef POSITION_INDEX
@@ -2973,7 +2973,7 @@ static inline uint8_t get_quotes_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[QUOTES_INDEX];
 	bits &= QUOTES_MASK;
 	bits >>= QUOTES_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -2985,11 +2985,11 @@ static inline uint8_t get_quotes(const css_computed_style *style, lwc_string
 	uint32_t bits = style->i.bits[QUOTES_INDEX];
 	bits &= QUOTES_MASK;
 	bits >>= QUOTES_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*string_arr = style->quotes;
-	
+
 	return type;
 }
 #undef QUOTES_INDEX
@@ -3005,7 +3005,7 @@ static inline uint8_t get_right_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[RIGHT_INDEX];
 	bits &= RIGHT_MASK;
 	bits >>= RIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -3017,14 +3017,14 @@ static inline uint8_t get_right(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[RIGHT_INDEX];
 	bits &= RIGHT_MASK;
 	bits >>= RIGHT_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_RIGHT_SET) {
 		*length = style->i.right;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef RIGHT_INDEX
@@ -3040,7 +3040,7 @@ static inline uint8_t get_stroke_opacity_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[STROKE_OPACITY_INDEX];
 	bits &= STROKE_OPACITY_MASK;
 	bits >>= STROKE_OPACITY_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -3052,13 +3052,13 @@ static inline uint8_t get_stroke_opacity(const css_computed_style *style,
 	uint32_t bits = style->i.bits[STROKE_OPACITY_INDEX];
 	bits &= STROKE_OPACITY_MASK;
 	bits >>= STROKE_OPACITY_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	if (type == CSS_STROKE_OPACITY_SET) {
 		*fixed = style->i.stroke_opacity;
 	}
-	
+
 	return type;
 }
 #undef STROKE_OPACITY_INDEX
@@ -3074,7 +3074,7 @@ static inline uint8_t get_table_layout_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TABLE_LAYOUT_INDEX];
 	bits &= TABLE_LAYOUT_MASK;
 	bits >>= TABLE_LAYOUT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -3085,10 +3085,10 @@ static inline uint8_t get_table_layout(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TABLE_LAYOUT_INDEX];
 	bits &= TABLE_LAYOUT_MASK;
 	bits >>= TABLE_LAYOUT_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef TABLE_LAYOUT_INDEX
@@ -3104,7 +3104,7 @@ static inline uint8_t get_text_align_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TEXT_ALIGN_INDEX];
 	bits &= TEXT_ALIGN_MASK;
 	bits >>= TEXT_ALIGN_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
 	return type;
@@ -3115,10 +3115,10 @@ static inline uint8_t get_text_align(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TEXT_ALIGN_INDEX];
 	bits &= TEXT_ALIGN_MASK;
 	bits >>= TEXT_ALIGN_SHIFT;
-	
+
 	/* 4bits: tttt : type */
 	type = bits & 0xf;
-	
+
 	return type;
 }
 #undef TEXT_ALIGN_INDEX
@@ -3134,7 +3134,7 @@ static inline uint8_t get_text_decoration_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TEXT_DECORATION_INDEX];
 	bits &= TEXT_DECORATION_MASK;
 	bits >>= TEXT_DECORATION_SHIFT;
-	
+
 	/* 5bits: ttttt : type */
 	type = bits & 0x1f;
 	return type;
@@ -3145,10 +3145,10 @@ static inline uint8_t get_text_decoration(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TEXT_DECORATION_INDEX];
 	bits &= TEXT_DECORATION_MASK;
 	bits >>= TEXT_DECORATION_SHIFT;
-	
+
 	/* 5bits: ttttt : type */
 	type = bits & 0x1f;
-	
+
 	return type;
 }
 #undef TEXT_DECORATION_INDEX
@@ -3164,7 +3164,7 @@ static inline uint8_t get_text_indent_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TEXT_INDENT_INDEX];
 	bits &= TEXT_INDENT_MASK;
 	bits >>= TEXT_INDENT_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	return type;
@@ -3176,14 +3176,14 @@ static inline uint8_t get_text_indent(const css_computed_style *style,
 	uint32_t bits = style->i.bits[TEXT_INDENT_INDEX];
 	bits &= TEXT_INDENT_MASK;
 	bits >>= TEXT_INDENT_SHIFT;
-	
+
 	/* 6bits: uuuuut : unit | type */
 	type = bits & 0x1;
 	if (type == CSS_TEXT_INDENT_SET) {
 		*length = style->i.text_indent;
 		*unit = bits >> 1;
 	}
-	
+
 	return type;
 }
 #undef TEXT_INDENT_INDEX
@@ -3199,7 +3199,7 @@ static inline uint8_t get_text_transform_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TEXT_TRANSFORM_INDEX];
 	bits &= TEXT_TRANSFORM_MASK;
 	bits >>= TEXT_TRANSFORM_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -3210,10 +3210,10 @@ static inline uint8_t get_text_transform(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TEXT_TRANSFORM_INDEX];
 	bits &= TEXT_TRANSFORM_MASK;
 	bits >>= TEXT_TRANSFORM_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef TEXT_TRANSFORM_INDEX
@@ -3229,7 +3229,7 @@ static inline uint8_t get_top_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[TOP_INDEX];
 	bits &= TOP_MASK;
 	bits >>= TOP_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -3241,14 +3241,14 @@ static inline uint8_t get_top(const css_computed_style *style, css_fixed
 	uint32_t bits = style->i.bits[TOP_INDEX];
 	bits &= TOP_MASK;
 	bits >>= TOP_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_TOP_SET) {
 		*length = style->i.top;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef TOP_INDEX
@@ -3264,7 +3264,7 @@ static inline uint8_t get_unicode_bidi_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[UNICODE_BIDI_INDEX];
 	bits &= UNICODE_BIDI_MASK;
 	bits >>= UNICODE_BIDI_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -3275,10 +3275,10 @@ static inline uint8_t get_unicode_bidi(const css_computed_style *style)
 	uint32_t bits = style->i.bits[UNICODE_BIDI_INDEX];
 	bits &= UNICODE_BIDI_MASK;
 	bits >>= UNICODE_BIDI_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef UNICODE_BIDI_INDEX
@@ -3294,7 +3294,7 @@ static inline uint8_t get_vertical_align_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[VERTICAL_ALIGN_INDEX];
 	bits &= VERTICAL_ALIGN_MASK;
 	bits >>= VERTICAL_ALIGN_SHIFT;
-	
+
 	/* 9bits: uuuuutttt : unit | type */
 	type = bits & 0xf;
 	return type;
@@ -3306,14 +3306,14 @@ static inline uint8_t get_vertical_align(const css_computed_style *style,
 	uint32_t bits = style->i.bits[VERTICAL_ALIGN_INDEX];
 	bits &= VERTICAL_ALIGN_MASK;
 	bits >>= VERTICAL_ALIGN_SHIFT;
-	
+
 	/* 9bits: uuuuutttt : unit | type */
 	type = bits & 0xf;
 	if (type == CSS_VERTICAL_ALIGN_SET) {
 		*length = style->i.vertical_align;
 		*unit = bits >> 4;
 	}
-	
+
 	return type;
 }
 #undef VERTICAL_ALIGN_INDEX
@@ -3329,7 +3329,7 @@ static inline uint8_t get_visibility_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[VISIBILITY_INDEX];
 	bits &= VISIBILITY_MASK;
 	bits >>= VISIBILITY_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -3340,10 +3340,10 @@ static inline uint8_t get_visibility(const css_computed_style *style)
 	uint32_t bits = style->i.bits[VISIBILITY_INDEX];
 	bits &= VISIBILITY_MASK;
 	bits >>= VISIBILITY_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef VISIBILITY_INDEX
@@ -3359,7 +3359,7 @@ static inline uint8_t get_white_space_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[WHITE_SPACE_INDEX];
 	bits &= WHITE_SPACE_MASK;
 	bits >>= WHITE_SPACE_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
 	return type;
@@ -3370,10 +3370,10 @@ static inline uint8_t get_white_space(const css_computed_style *style)
 	uint32_t bits = style->i.bits[WHITE_SPACE_INDEX];
 	bits &= WHITE_SPACE_MASK;
 	bits >>= WHITE_SPACE_SHIFT;
-	
+
 	/* 3bits: ttt : type */
 	type = bits & 0x7;
-	
+
 	return type;
 }
 #undef WHITE_SPACE_INDEX
@@ -3389,7 +3389,7 @@ static inline uint8_t get_widows_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[WIDOWS_INDEX];
 	bits &= WIDOWS_MASK;
 	bits >>= WIDOWS_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	return type;
@@ -3401,11 +3401,11 @@ static inline uint8_t get_widows(const css_computed_style *style, int32_t
 	uint32_t bits = style->i.bits[WIDOWS_INDEX];
 	bits &= WIDOWS_MASK;
 	bits >>= WIDOWS_SHIFT;
-	
+
 	/* 1bit: t : type */
 	type = bits & 0x1;
 	*integer = style->i.widows;
-	
+
 	return type;
 }
 #undef WIDOWS_INDEX
@@ -3421,7 +3421,7 @@ static inline uint8_t get_width_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[WIDTH_INDEX];
 	bits &= WIDTH_MASK;
 	bits >>= WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -3433,14 +3433,14 @@ static inline uint8_t get_width(const css_computed_style *style,
 	uint32_t bits = style->i.bits[WIDTH_INDEX];
 	bits &= WIDTH_MASK;
 	bits >>= WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_WIDTH_SET) {
 		*length = style->i.width;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef WIDTH_INDEX
@@ -3456,7 +3456,7 @@ static inline uint8_t get_word_spacing_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[WORD_SPACING_INDEX];
 	bits &= WORD_SPACING_MASK;
 	bits >>= WORD_SPACING_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	return type;
@@ -3468,14 +3468,14 @@ static inline uint8_t get_word_spacing(const css_computed_style *style,
 	uint32_t bits = style->i.bits[WORD_SPACING_INDEX];
 	bits &= WORD_SPACING_MASK;
 	bits >>= WORD_SPACING_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	type = bits & 0x3;
 	if (type == CSS_WORD_SPACING_SET) {
 		*length = style->i.word_spacing;
 		*unit = bits >> 2;
 	}
-	
+
 	return type;
 }
 #undef WORD_SPACING_INDEX
@@ -3491,7 +3491,7 @@ static inline uint8_t get_writing_mode_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[WRITING_MODE_INDEX];
 	bits &= WRITING_MODE_MASK;
 	bits >>= WRITING_MODE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -3502,10 +3502,10 @@ static inline uint8_t get_writing_mode(const css_computed_style *style)
 	uint32_t bits = style->i.bits[WRITING_MODE_INDEX];
 	bits &= WRITING_MODE_MASK;
 	bits >>= WRITING_MODE_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
-	
+
 	return type;
 }
 #undef WRITING_MODE_INDEX
@@ -3521,7 +3521,7 @@ static inline uint8_t get_z_index_bits(const css_computed_style *style)
 	uint32_t bits = style->i.bits[Z_INDEX_INDEX];
 	bits &= Z_INDEX_MASK;
 	bits >>= Z_INDEX_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	return type;
@@ -3533,11 +3533,11 @@ static inline uint8_t get_z_index(const css_computed_style *style, int32_t
 	uint32_t bits = style->i.bits[Z_INDEX_INDEX];
 	bits &= Z_INDEX_MASK;
 	bits >>= Z_INDEX_SHIFT;
-	
+
 	/* 2bits: tt : type */
 	type = bits & 0x3;
 	*integer = style->i.z_index;
-	
+
 	return type;
 }
 #undef Z_INDEX_INDEX

--- a/src/select/autogenerated_propget.h
+++ b/src/select/autogenerated_propget.h
@@ -14,22 +14,26 @@
 #define ALIGN_CONTENT_MASK 0x700000
 static inline uint8_t get_align_content_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ALIGN_CONTENT_INDEX];
 	bits &= ALIGN_CONTENT_MASK;
 	bits >>= ALIGN_CONTENT_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_align_content(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ALIGN_CONTENT_INDEX];
 	bits &= ALIGN_CONTENT_MASK;
 	bits >>= ALIGN_CONTENT_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef ALIGN_CONTENT_INDEX
 #undef ALIGN_CONTENT_SHIFT
@@ -40,22 +44,26 @@ static inline uint8_t get_align_content(const css_computed_style *style)
 #define ALIGN_ITEMS_MASK 0x3800000
 static inline uint8_t get_align_items_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ALIGN_ITEMS_INDEX];
 	bits &= ALIGN_ITEMS_MASK;
 	bits >>= ALIGN_ITEMS_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_align_items(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ALIGN_ITEMS_INDEX];
 	bits &= ALIGN_ITEMS_MASK;
 	bits >>= ALIGN_ITEMS_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef ALIGN_ITEMS_INDEX
 #undef ALIGN_ITEMS_SHIFT
@@ -66,22 +74,26 @@ static inline uint8_t get_align_items(const css_computed_style *style)
 #define ALIGN_SELF_MASK 0x1c000000
 static inline uint8_t get_align_self_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ALIGN_SELF_INDEX];
 	bits &= ALIGN_SELF_MASK;
 	bits >>= ALIGN_SELF_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_align_self(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ALIGN_SELF_INDEX];
 	bits &= ALIGN_SELF_MASK;
 	bits >>= ALIGN_SELF_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef ALIGN_SELF_INDEX
 #undef ALIGN_SELF_SHIFT
@@ -93,22 +105,26 @@ static inline uint8_t get_align_self(const css_computed_style *style)
 static inline uint8_t get_background_attachment_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_ATTACHMENT_INDEX];
 	bits &= BACKGROUND_ATTACHMENT_MASK;
 	bits >>= BACKGROUND_ATTACHMENT_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_background_attachment(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_ATTACHMENT_INDEX];
 	bits &= BACKGROUND_ATTACHMENT_MASK;
 	bits >>= BACKGROUND_ATTACHMENT_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BACKGROUND_ATTACHMENT_INDEX
 #undef BACKGROUND_ATTACHMENT_SHIFT
@@ -119,24 +135,28 @@ static inline uint8_t get_background_attachment(const css_computed_style *style)
 #define BACKGROUND_COLOR_MASK 0xc0000000
 static inline uint8_t get_background_color_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_COLOR_INDEX];
 	bits &= BACKGROUND_COLOR_MASK;
 	bits >>= BACKGROUND_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_background_color(const css_computed_style *style,
 		css_color *color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_COLOR_INDEX];
 	bits &= BACKGROUND_COLOR_MASK;
 	bits >>= BACKGROUND_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*color = style->i.background_color;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BACKGROUND_COLOR_INDEX
 #undef BACKGROUND_COLOR_SHIFT
@@ -147,24 +167,28 @@ static inline uint8_t get_background_color(const css_computed_style *style,
 #define BACKGROUND_IMAGE_MASK 0x10000
 static inline uint8_t get_background_image_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_IMAGE_INDEX];
 	bits &= BACKGROUND_IMAGE_MASK;
 	bits >>= BACKGROUND_IMAGE_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_background_image(const css_computed_style *style,
 		lwc_string **string)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_IMAGE_INDEX];
 	bits &= BACKGROUND_IMAGE_MASK;
 	bits >>= BACKGROUND_IMAGE_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*string = style->i.background_image;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef BACKGROUND_IMAGE_INDEX
 #undef BACKGROUND_IMAGE_SHIFT
@@ -176,30 +200,34 @@ static inline uint8_t get_background_image(const css_computed_style *style,
 static inline uint8_t get_background_position_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_POSITION_INDEX];
 	bits &= BACKGROUND_POSITION_MASK;
 	bits >>= BACKGROUND_POSITION_SHIFT;
 	
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_background_position(const css_computed_style *style,
 		css_fixed *length_a, css_unit *unit_a, css_fixed *length_b,
 		css_unit *unit_b)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_POSITION_INDEX];
 	bits &= BACKGROUND_POSITION_MASK;
 	bits >>= BACKGROUND_POSITION_SHIFT;
 	
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
-	if ((bits & 0x1) == CSS_BACKGROUND_POSITION_SET) {
+	type = bits & 0x1;
+	if (type == CSS_BACKGROUND_POSITION_SET) {
 		*length_a = style->i.background_position_a;
 		*length_b = style->i.background_position_b;
 		*unit_a = bits >> 6;
 		*unit_b = (bits & 0x3e) >> 1;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef BACKGROUND_POSITION_INDEX
 #undef BACKGROUND_POSITION_SHIFT
@@ -211,22 +239,26 @@ static inline uint8_t get_background_position(const css_computed_style *style,
 static inline uint8_t get_background_repeat_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_REPEAT_INDEX];
 	bits &= BACKGROUND_REPEAT_MASK;
 	bits >>= BACKGROUND_REPEAT_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_background_repeat(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BACKGROUND_REPEAT_INDEX];
 	bits &= BACKGROUND_REPEAT_MASK;
 	bits >>= BACKGROUND_REPEAT_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef BACKGROUND_REPEAT_INDEX
 #undef BACKGROUND_REPEAT_SHIFT
@@ -238,24 +270,28 @@ static inline uint8_t get_background_repeat(const css_computed_style *style)
 static inline uint8_t get_border_bottom_color_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_COLOR_INDEX];
 	bits &= BORDER_BOTTOM_COLOR_MASK;
 	bits >>= BORDER_BOTTOM_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_border_bottom_color(const css_computed_style *style,
 		css_color *color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_COLOR_INDEX];
 	bits &= BORDER_BOTTOM_COLOR_MASK;
 	bits >>= BORDER_BOTTOM_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*color = style->i.border_bottom_color;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BORDER_BOTTOM_COLOR_INDEX
 #undef BORDER_BOTTOM_COLOR_SHIFT
@@ -267,22 +303,26 @@ static inline uint8_t get_border_bottom_color(const css_computed_style *style,
 static inline uint8_t get_border_bottom_style_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_STYLE_INDEX];
 	bits &= BORDER_BOTTOM_STYLE_MASK;
 	bits >>= BORDER_BOTTOM_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_border_bottom_style(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_STYLE_INDEX];
 	bits &= BORDER_BOTTOM_STYLE_MASK;
 	bits >>= BORDER_BOTTOM_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef BORDER_BOTTOM_STYLE_INDEX
 #undef BORDER_BOTTOM_STYLE_SHIFT
@@ -294,27 +334,31 @@ static inline uint8_t get_border_bottom_style(const css_computed_style *style)
 static inline uint8_t get_border_bottom_width_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_WIDTH_INDEX];
 	bits &= BORDER_BOTTOM_WIDTH_MASK;
 	bits >>= BORDER_BOTTOM_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_border_bottom_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_BOTTOM_WIDTH_INDEX];
 	bits &= BORDER_BOTTOM_WIDTH_MASK;
 	bits >>= BORDER_BOTTOM_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	if ((bits & 0x7) == CSS_BORDER_WIDTH_WIDTH) {
+	type = bits & 0x7;
+	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_bottom_width;
 		*unit = bits >> 3;
 	}
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef BORDER_BOTTOM_WIDTH_INDEX
 #undef BORDER_BOTTOM_WIDTH_SHIFT
@@ -325,22 +369,26 @@ static inline uint8_t get_border_bottom_width(const css_computed_style *style,
 #define BORDER_COLLAPSE_MASK 0xc
 static inline uint8_t get_border_collapse_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_COLLAPSE_INDEX];
 	bits &= BORDER_COLLAPSE_MASK;
 	bits >>= BORDER_COLLAPSE_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_border_collapse(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_COLLAPSE_INDEX];
 	bits &= BORDER_COLLAPSE_MASK;
 	bits >>= BORDER_COLLAPSE_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BORDER_COLLAPSE_INDEX
 #undef BORDER_COLLAPSE_SHIFT
@@ -352,24 +400,28 @@ static inline uint8_t get_border_collapse(const css_computed_style *style)
 static inline uint8_t get_border_left_color_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_LEFT_COLOR_INDEX];
 	bits &= BORDER_LEFT_COLOR_MASK;
 	bits >>= BORDER_LEFT_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_border_left_color(const css_computed_style *style,
 		css_color *color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_LEFT_COLOR_INDEX];
 	bits &= BORDER_LEFT_COLOR_MASK;
 	bits >>= BORDER_LEFT_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*color = style->i.border_left_color;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BORDER_LEFT_COLOR_INDEX
 #undef BORDER_LEFT_COLOR_SHIFT
@@ -381,22 +433,26 @@ static inline uint8_t get_border_left_color(const css_computed_style *style,
 static inline uint8_t get_border_left_style_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_LEFT_STYLE_INDEX];
 	bits &= BORDER_LEFT_STYLE_MASK;
 	bits >>= BORDER_LEFT_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_border_left_style(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_LEFT_STYLE_INDEX];
 	bits &= BORDER_LEFT_STYLE_MASK;
 	bits >>= BORDER_LEFT_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef BORDER_LEFT_STYLE_INDEX
 #undef BORDER_LEFT_STYLE_SHIFT
@@ -408,27 +464,31 @@ static inline uint8_t get_border_left_style(const css_computed_style *style)
 static inline uint8_t get_border_left_width_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_LEFT_WIDTH_INDEX];
 	bits &= BORDER_LEFT_WIDTH_MASK;
 	bits >>= BORDER_LEFT_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_border_left_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_LEFT_WIDTH_INDEX];
 	bits &= BORDER_LEFT_WIDTH_MASK;
 	bits >>= BORDER_LEFT_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	if ((bits & 0x7) == CSS_BORDER_WIDTH_WIDTH) {
+	type = bits & 0x7;
+	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_left_width;
 		*unit = bits >> 3;
 	}
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef BORDER_LEFT_WIDTH_INDEX
 #undef BORDER_LEFT_WIDTH_SHIFT
@@ -440,24 +500,28 @@ static inline uint8_t get_border_left_width(const css_computed_style *style,
 static inline uint8_t get_border_right_color_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_RIGHT_COLOR_INDEX];
 	bits &= BORDER_RIGHT_COLOR_MASK;
 	bits >>= BORDER_RIGHT_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_border_right_color(const css_computed_style *style,
 		css_color *color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_RIGHT_COLOR_INDEX];
 	bits &= BORDER_RIGHT_COLOR_MASK;
 	bits >>= BORDER_RIGHT_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*color = style->i.border_right_color;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BORDER_RIGHT_COLOR_INDEX
 #undef BORDER_RIGHT_COLOR_SHIFT
@@ -469,22 +533,26 @@ static inline uint8_t get_border_right_color(const css_computed_style *style,
 static inline uint8_t get_border_right_style_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_RIGHT_STYLE_INDEX];
 	bits &= BORDER_RIGHT_STYLE_MASK;
 	bits >>= BORDER_RIGHT_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_border_right_style(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_RIGHT_STYLE_INDEX];
 	bits &= BORDER_RIGHT_STYLE_MASK;
 	bits >>= BORDER_RIGHT_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef BORDER_RIGHT_STYLE_INDEX
 #undef BORDER_RIGHT_STYLE_SHIFT
@@ -496,27 +564,31 @@ static inline uint8_t get_border_right_style(const css_computed_style *style)
 static inline uint8_t get_border_right_width_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_RIGHT_WIDTH_INDEX];
 	bits &= BORDER_RIGHT_WIDTH_MASK;
 	bits >>= BORDER_RIGHT_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_border_right_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_RIGHT_WIDTH_INDEX];
 	bits &= BORDER_RIGHT_WIDTH_MASK;
 	bits >>= BORDER_RIGHT_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	if ((bits & 0x7) == CSS_BORDER_WIDTH_WIDTH) {
+	type = bits & 0x7;
+	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_right_width;
 		*unit = bits >> 3;
 	}
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef BORDER_RIGHT_WIDTH_INDEX
 #undef BORDER_RIGHT_WIDTH_SHIFT
@@ -527,30 +599,34 @@ static inline uint8_t get_border_right_width(const css_computed_style *style,
 #define BORDER_SPACING_MASK 0xffe00000
 static inline uint8_t get_border_spacing_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_SPACING_INDEX];
 	bits &= BORDER_SPACING_MASK;
 	bits >>= BORDER_SPACING_SHIFT;
 	
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_border_spacing(const css_computed_style *style,
 		css_fixed *length_a, css_unit *unit_a, css_fixed *length_b,
 		css_unit *unit_b)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_SPACING_INDEX];
 	bits &= BORDER_SPACING_MASK;
 	bits >>= BORDER_SPACING_SHIFT;
 	
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
-	if ((bits & 0x1) == CSS_BORDER_SPACING_SET) {
+	type = bits & 0x1;
+	if (type == CSS_BORDER_SPACING_SET) {
 		*length_a = style->i.border_spacing_a;
 		*length_b = style->i.border_spacing_b;
 		*unit_a = bits >> 6;
 		*unit_b = (bits & 0x3e) >> 1;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef BORDER_SPACING_INDEX
 #undef BORDER_SPACING_SHIFT
@@ -561,24 +637,28 @@ static inline uint8_t get_border_spacing(const css_computed_style *style,
 #define BORDER_TOP_COLOR_MASK 0x300
 static inline uint8_t get_border_top_color_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_TOP_COLOR_INDEX];
 	bits &= BORDER_TOP_COLOR_MASK;
 	bits >>= BORDER_TOP_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_border_top_color(const css_computed_style *style,
 		css_color *color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_TOP_COLOR_INDEX];
 	bits &= BORDER_TOP_COLOR_MASK;
 	bits >>= BORDER_TOP_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*color = style->i.border_top_color;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BORDER_TOP_COLOR_INDEX
 #undef BORDER_TOP_COLOR_SHIFT
@@ -589,22 +669,26 @@ static inline uint8_t get_border_top_color(const css_computed_style *style,
 #define BORDER_TOP_STYLE_MASK 0x7800
 static inline uint8_t get_border_top_style_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_TOP_STYLE_INDEX];
 	bits &= BORDER_TOP_STYLE_MASK;
 	bits >>= BORDER_TOP_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_border_top_style(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_TOP_STYLE_INDEX];
 	bits &= BORDER_TOP_STYLE_MASK;
 	bits >>= BORDER_TOP_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef BORDER_TOP_STYLE_INDEX
 #undef BORDER_TOP_STYLE_SHIFT
@@ -615,27 +699,31 @@ static inline uint8_t get_border_top_style(const css_computed_style *style)
 #define BORDER_TOP_WIDTH_MASK 0xff000000
 static inline uint8_t get_border_top_width_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_TOP_WIDTH_INDEX];
 	bits &= BORDER_TOP_WIDTH_MASK;
 	bits >>= BORDER_TOP_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_border_top_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BORDER_TOP_WIDTH_INDEX];
 	bits &= BORDER_TOP_WIDTH_MASK;
 	bits >>= BORDER_TOP_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	if ((bits & 0x7) == CSS_BORDER_WIDTH_WIDTH) {
+	type = bits & 0x7;
+	if (type == CSS_BORDER_WIDTH_WIDTH) {
 		*length = style->i.border_top_width;
 		*unit = bits >> 3;
 	}
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef BORDER_TOP_WIDTH_INDEX
 #undef BORDER_TOP_WIDTH_SHIFT
@@ -646,27 +734,31 @@ static inline uint8_t get_border_top_width(const css_computed_style *style,
 #define BOTTOM_MASK 0x3f800
 static inline uint8_t get_bottom_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BOTTOM_INDEX];
 	bits &= BOTTOM_MASK;
 	bits >>= BOTTOM_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_bottom(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BOTTOM_INDEX];
 	bits &= BOTTOM_MASK;
 	bits >>= BOTTOM_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_BOTTOM_SET) {
+	type = bits & 0x3;
+	if (type == CSS_BOTTOM_SET) {
 		*length = style->i.bottom;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BOTTOM_INDEX
 #undef BOTTOM_SHIFT
@@ -677,22 +769,26 @@ static inline uint8_t get_bottom(const css_computed_style *style, css_fixed
 #define BOX_SIZING_MASK 0xc00
 static inline uint8_t get_box_sizing_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BOX_SIZING_INDEX];
 	bits &= BOX_SIZING_MASK;
 	bits >>= BOX_SIZING_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_box_sizing(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BOX_SIZING_INDEX];
 	bits &= BOX_SIZING_MASK;
 	bits >>= BOX_SIZING_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef BOX_SIZING_INDEX
 #undef BOX_SIZING_SHIFT
@@ -703,22 +799,26 @@ static inline uint8_t get_box_sizing(const css_computed_style *style)
 #define BREAK_AFTER_MASK 0x78000
 static inline uint8_t get_break_after_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BREAK_AFTER_INDEX];
 	bits &= BREAK_AFTER_MASK;
 	bits >>= BREAK_AFTER_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_break_after(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BREAK_AFTER_INDEX];
 	bits &= BREAK_AFTER_MASK;
 	bits >>= BREAK_AFTER_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef BREAK_AFTER_INDEX
 #undef BREAK_AFTER_SHIFT
@@ -729,22 +829,26 @@ static inline uint8_t get_break_after(const css_computed_style *style)
 #define BREAK_BEFORE_MASK 0x780000
 static inline uint8_t get_break_before_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BREAK_BEFORE_INDEX];
 	bits &= BREAK_BEFORE_MASK;
 	bits >>= BREAK_BEFORE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_break_before(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BREAK_BEFORE_INDEX];
 	bits &= BREAK_BEFORE_MASK;
 	bits >>= BREAK_BEFORE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef BREAK_BEFORE_INDEX
 #undef BREAK_BEFORE_SHIFT
@@ -755,22 +859,26 @@ static inline uint8_t get_break_before(const css_computed_style *style)
 #define BREAK_INSIDE_MASK 0x7800000
 static inline uint8_t get_break_inside_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BREAK_INSIDE_INDEX];
 	bits &= BREAK_INSIDE_MASK;
 	bits >>= BREAK_INSIDE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_break_inside(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[BREAK_INSIDE_INDEX];
 	bits &= BREAK_INSIDE_MASK;
 	bits >>= BREAK_INSIDE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef BREAK_INSIDE_INDEX
 #undef BREAK_INSIDE_SHIFT
@@ -781,22 +889,26 @@ static inline uint8_t get_break_inside(const css_computed_style *style)
 #define CAPTION_SIDE_MASK 0x3000
 static inline uint8_t get_caption_side_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CAPTION_SIDE_INDEX];
 	bits &= CAPTION_SIDE_MASK;
 	bits >>= CAPTION_SIDE_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_caption_side(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CAPTION_SIDE_INDEX];
 	bits &= CAPTION_SIDE_MASK;
 	bits >>= CAPTION_SIDE_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef CAPTION_SIDE_INDEX
 #undef CAPTION_SIDE_SHIFT
@@ -807,22 +919,26 @@ static inline uint8_t get_caption_side(const css_computed_style *style)
 #define CLEAR_MASK 0xe
 static inline uint8_t get_clear_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CLEAR_INDEX];
 	bits &= CLEAR_MASK;
 	bits >>= CLEAR_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_clear(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CLEAR_INDEX];
 	bits &= CLEAR_MASK;
 	bits >>= CLEAR_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef CLEAR_INDEX
 #undef CLEAR_SHIFT
@@ -833,13 +949,15 @@ static inline uint8_t get_clear(const css_computed_style *style)
 #define CLIP_MASK 0xffffffc0
 static inline uint8_t get_clip_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CLIP_INDEX];
 	bits &= CLIP_MASK;
 	bits >>= CLIP_SHIFT;
 	
 	/* 26bits: aaaaabbbbbcccccdddddtttttt : unit_a | unit_b | unit_c |
 			unit_d | type */
-	return (bits & 0x3f);
+	type = bits & 0x3f;
+	return type;
 }
 static inline uint8_t get_clip(
 		const css_computed_style *style,
@@ -885,24 +1003,28 @@ static inline uint8_t get_clip(
 #define COLOR_MASK 0x20000
 static inline uint8_t get_color_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLOR_INDEX];
 	bits &= COLOR_MASK;
 	bits >>= COLOR_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_color(const css_computed_style *style, css_color
 		*color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLOR_INDEX];
 	bits &= COLOR_MASK;
 	bits >>= COLOR_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*color = style->i.color;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef COLOR_INDEX
 #undef COLOR_SHIFT
@@ -913,24 +1035,28 @@ static inline uint8_t get_color(const css_computed_style *style, css_color
 #define COLUMN_COUNT_MASK 0xc000
 static inline uint8_t get_column_count_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_COUNT_INDEX];
 	bits &= COLUMN_COUNT_MASK;
 	bits >>= COLUMN_COUNT_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_column_count(const css_computed_style *style, int32_t
 		*integer)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_COUNT_INDEX];
 	bits &= COLUMN_COUNT_MASK;
 	bits >>= COLUMN_COUNT_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*integer = style->i.column_count;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef COLUMN_COUNT_INDEX
 #undef COLUMN_COUNT_SHIFT
@@ -941,22 +1067,26 @@ static inline uint8_t get_column_count(const css_computed_style *style, int32_t
 #define COLUMN_FILL_MASK 0x30000
 static inline uint8_t get_column_fill_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_FILL_INDEX];
 	bits &= COLUMN_FILL_MASK;
 	bits >>= COLUMN_FILL_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_column_fill(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_FILL_INDEX];
 	bits &= COLUMN_FILL_MASK;
 	bits >>= COLUMN_FILL_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef COLUMN_FILL_INDEX
 #undef COLUMN_FILL_SHIFT
@@ -967,27 +1097,31 @@ static inline uint8_t get_column_fill(const css_computed_style *style)
 #define COLUMN_GAP_MASK 0x1fc0000
 static inline uint8_t get_column_gap_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_GAP_INDEX];
 	bits &= COLUMN_GAP_MASK;
 	bits >>= COLUMN_GAP_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_column_gap(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_GAP_INDEX];
 	bits &= COLUMN_GAP_MASK;
 	bits >>= COLUMN_GAP_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_COLUMN_GAP_SET) {
+	type = bits & 0x3;
+	if (type == CSS_COLUMN_GAP_SET) {
 		*length = style->i.column_gap;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef COLUMN_GAP_INDEX
 #undef COLUMN_GAP_SHIFT
@@ -999,24 +1133,28 @@ static inline uint8_t get_column_gap(const css_computed_style *style, css_fixed
 static inline uint8_t get_column_rule_color_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_RULE_COLOR_INDEX];
 	bits &= COLUMN_RULE_COLOR_MASK;
 	bits >>= COLUMN_RULE_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_column_rule_color(const css_computed_style *style,
 		css_color *color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_RULE_COLOR_INDEX];
 	bits &= COLUMN_RULE_COLOR_MASK;
 	bits >>= COLUMN_RULE_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*color = style->i.column_rule_color;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef COLUMN_RULE_COLOR_INDEX
 #undef COLUMN_RULE_COLOR_SHIFT
@@ -1028,22 +1166,26 @@ static inline uint8_t get_column_rule_color(const css_computed_style *style,
 static inline uint8_t get_column_rule_style_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_RULE_STYLE_INDEX];
 	bits &= COLUMN_RULE_STYLE_MASK;
 	bits >>= COLUMN_RULE_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_column_rule_style(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_RULE_STYLE_INDEX];
 	bits &= COLUMN_RULE_STYLE_MASK;
 	bits >>= COLUMN_RULE_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef COLUMN_RULE_STYLE_INDEX
 #undef COLUMN_RULE_STYLE_SHIFT
@@ -1055,27 +1197,31 @@ static inline uint8_t get_column_rule_style(const css_computed_style *style)
 static inline uint8_t get_column_rule_width_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_RULE_WIDTH_INDEX];
 	bits &= COLUMN_RULE_WIDTH_MASK;
 	bits >>= COLUMN_RULE_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_column_rule_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_RULE_WIDTH_INDEX];
 	bits &= COLUMN_RULE_WIDTH_MASK;
 	bits >>= COLUMN_RULE_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	if ((bits & 0x7) == CSS_COLUMN_RULE_WIDTH_WIDTH) {
+	type = bits & 0x7;
+	if (type == CSS_COLUMN_RULE_WIDTH_WIDTH) {
 		*length = style->i.column_rule_width;
 		*unit = bits >> 3;
 	}
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef COLUMN_RULE_WIDTH_INDEX
 #undef COLUMN_RULE_WIDTH_SHIFT
@@ -1086,22 +1232,26 @@ static inline uint8_t get_column_rule_width(const css_computed_style *style,
 #define COLUMN_SPAN_MASK 0x300000
 static inline uint8_t get_column_span_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_SPAN_INDEX];
 	bits &= COLUMN_SPAN_MASK;
 	bits >>= COLUMN_SPAN_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_column_span(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_SPAN_INDEX];
 	bits &= COLUMN_SPAN_MASK;
 	bits >>= COLUMN_SPAN_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef COLUMN_SPAN_INDEX
 #undef COLUMN_SPAN_SHIFT
@@ -1112,27 +1262,31 @@ static inline uint8_t get_column_span(const css_computed_style *style)
 #define COLUMN_WIDTH_MASK 0xfe000000
 static inline uint8_t get_column_width_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_WIDTH_INDEX];
 	bits &= COLUMN_WIDTH_MASK;
 	bits >>= COLUMN_WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_column_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COLUMN_WIDTH_INDEX];
 	bits &= COLUMN_WIDTH_MASK;
 	bits >>= COLUMN_WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_COLUMN_WIDTH_SET) {
+	type = bits & 0x3;
+	if (type == CSS_COLUMN_WIDTH_SET) {
 		*length = style->i.column_width;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef COLUMN_WIDTH_INDEX
 #undef COLUMN_WIDTH_SHIFT
@@ -1143,26 +1297,30 @@ static inline uint8_t get_column_width(const css_computed_style *style,
 #define CONTENT_MASK 0xc00000
 static inline uint8_t get_content_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CONTENT_INDEX];
 	bits &= CONTENT_MASK;
 	bits >>= CONTENT_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_content(const css_computed_style *style, const
 		css_computed_content_item **content_item)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CONTENT_INDEX];
 	bits &= CONTENT_MASK;
 	bits >>= CONTENT_SHIFT;
 	
 	/* 2bits: tt : type */
-	if ((bits & 0x3) == CSS_CONTENT_SET) {
+	type = bits & 0x3;
+	if (type == CSS_CONTENT_SET) {
 		*content_item = style->content;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef CONTENT_INDEX
 #undef CONTENT_SHIFT
@@ -1174,24 +1332,28 @@ static inline uint8_t get_content(const css_computed_style *style, const
 static inline uint8_t get_counter_increment_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COUNTER_INCREMENT_INDEX];
 	bits &= COUNTER_INCREMENT_MASK;
 	bits >>= COUNTER_INCREMENT_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_counter_increment(const css_computed_style *style,
 		const css_computed_counter **counter_arr)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COUNTER_INCREMENT_INDEX];
 	bits &= COUNTER_INCREMENT_MASK;
 	bits >>= COUNTER_INCREMENT_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*counter_arr = style->counter_increment;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef COUNTER_INCREMENT_INDEX
 #undef COUNTER_INCREMENT_SHIFT
@@ -1202,24 +1364,28 @@ static inline uint8_t get_counter_increment(const css_computed_style *style,
 #define COUNTER_RESET_MASK 0x80000
 static inline uint8_t get_counter_reset_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COUNTER_RESET_INDEX];
 	bits &= COUNTER_RESET_MASK;
 	bits >>= COUNTER_RESET_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_counter_reset(const css_computed_style *style, const
 		css_computed_counter **counter_arr)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[COUNTER_RESET_INDEX];
 	bits &= COUNTER_RESET_MASK;
 	bits >>= COUNTER_RESET_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*counter_arr = style->counter_reset;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef COUNTER_RESET_INDEX
 #undef COUNTER_RESET_SHIFT
@@ -1230,24 +1396,28 @@ static inline uint8_t get_counter_reset(const css_computed_style *style, const
 #define CURSOR_MASK 0xf8000000
 static inline uint8_t get_cursor_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CURSOR_INDEX];
 	bits &= CURSOR_MASK;
 	bits >>= CURSOR_SHIFT;
 	
 	/* 5bits: ttttt : type */
-	return (bits & 0x1f);
+	type = bits & 0x1f;
+	return type;
 }
 static inline uint8_t get_cursor(const css_computed_style *style, lwc_string
 		***string_arr)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[CURSOR_INDEX];
 	bits &= CURSOR_MASK;
 	bits >>= CURSOR_SHIFT;
 	
 	/* 5bits: ttttt : type */
+	type = bits & 0x1f;
 	*string_arr = style->cursor;
 	
-	return (bits & 0x1f);
+	return type;
 }
 #undef CURSOR_INDEX
 #undef CURSOR_SHIFT
@@ -1258,22 +1428,26 @@ static inline uint8_t get_cursor(const css_computed_style *style, lwc_string
 #define DIRECTION_MASK 0x3000000
 static inline uint8_t get_direction_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[DIRECTION_INDEX];
 	bits &= DIRECTION_MASK;
 	bits >>= DIRECTION_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_direction(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[DIRECTION_INDEX];
 	bits &= DIRECTION_MASK;
 	bits >>= DIRECTION_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef DIRECTION_INDEX
 #undef DIRECTION_SHIFT
@@ -1284,22 +1458,26 @@ static inline uint8_t get_direction(const css_computed_style *style)
 #define DISPLAY_MASK 0xf8
 static inline uint8_t get_display_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[DISPLAY_INDEX];
 	bits &= DISPLAY_MASK;
 	bits >>= DISPLAY_SHIFT;
 	
 	/* 5bits: ttttt : type */
-	return (bits & 0x1f);
+	type = bits & 0x1f;
+	return type;
 }
 static inline uint8_t get_display(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[DISPLAY_INDEX];
 	bits &= DISPLAY_MASK;
 	bits >>= DISPLAY_SHIFT;
 	
 	/* 5bits: ttttt : type */
+	type = bits & 0x1f;
 	
-	return (bits & 0x1f);
+	return type;
 }
 #undef DISPLAY_INDEX
 #undef DISPLAY_SHIFT
@@ -1310,22 +1488,26 @@ static inline uint8_t get_display(const css_computed_style *style)
 #define EMPTY_CELLS_MASK 0xc000000
 static inline uint8_t get_empty_cells_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[EMPTY_CELLS_INDEX];
 	bits &= EMPTY_CELLS_MASK;
 	bits >>= EMPTY_CELLS_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_empty_cells(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[EMPTY_CELLS_INDEX];
 	bits &= EMPTY_CELLS_MASK;
 	bits >>= EMPTY_CELLS_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef EMPTY_CELLS_INDEX
 #undef EMPTY_CELLS_SHIFT
@@ -1336,26 +1518,30 @@ static inline uint8_t get_empty_cells(const css_computed_style *style)
 #define FILL_OPACITY_MASK 0x100000
 static inline uint8_t get_fill_opacity_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FILL_OPACITY_INDEX];
 	bits &= FILL_OPACITY_MASK;
 	bits >>= FILL_OPACITY_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_fill_opacity(const css_computed_style *style,
 		css_fixed *fixed)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FILL_OPACITY_INDEX];
 	bits &= FILL_OPACITY_MASK;
 	bits >>= FILL_OPACITY_SHIFT;
 	
 	/* 1bit: t : type */
-	if ((bits & 0x1) == CSS_FILL_OPACITY_SET) {
+	type = bits & 0x1;
+	if (type == CSS_FILL_OPACITY_SET) {
 		*fixed = style->i.fill_opacity;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef FILL_OPACITY_INDEX
 #undef FILL_OPACITY_SHIFT
@@ -1366,27 +1552,31 @@ static inline uint8_t get_fill_opacity(const css_computed_style *style,
 #define FLEX_BASIS_MASK 0x7f0
 static inline uint8_t get_flex_basis_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_BASIS_INDEX];
 	bits &= FLEX_BASIS_MASK;
 	bits >>= FLEX_BASIS_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_flex_basis(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_BASIS_INDEX];
 	bits &= FLEX_BASIS_MASK;
 	bits >>= FLEX_BASIS_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_FLEX_BASIS_SET) {
+	type = bits & 0x3;
+	if (type == CSS_FLEX_BASIS_SET) {
 		*length = style->i.flex_basis;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef FLEX_BASIS_INDEX
 #undef FLEX_BASIS_SHIFT
@@ -1397,22 +1587,26 @@ static inline uint8_t get_flex_basis(const css_computed_style *style, css_fixed
 #define FLEX_DIRECTION_MASK 0x70
 static inline uint8_t get_flex_direction_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_DIRECTION_INDEX];
 	bits &= FLEX_DIRECTION_MASK;
 	bits >>= FLEX_DIRECTION_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_flex_direction(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_DIRECTION_INDEX];
 	bits &= FLEX_DIRECTION_MASK;
 	bits >>= FLEX_DIRECTION_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef FLEX_DIRECTION_INDEX
 #undef FLEX_DIRECTION_SHIFT
@@ -1423,26 +1617,30 @@ static inline uint8_t get_flex_direction(const css_computed_style *style)
 #define FLEX_GROW_MASK 0x200000
 static inline uint8_t get_flex_grow_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_GROW_INDEX];
 	bits &= FLEX_GROW_MASK;
 	bits >>= FLEX_GROW_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_flex_grow(const css_computed_style *style, css_fixed
 		*fixed)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_GROW_INDEX];
 	bits &= FLEX_GROW_MASK;
 	bits >>= FLEX_GROW_SHIFT;
 	
 	/* 1bit: t : type */
-	if ((bits & 0x1) == CSS_FLEX_GROW_SET) {
+	type = bits & 0x1;
+	if (type == CSS_FLEX_GROW_SET) {
 		*fixed = style->i.flex_grow;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef FLEX_GROW_INDEX
 #undef FLEX_GROW_SHIFT
@@ -1453,26 +1651,30 @@ static inline uint8_t get_flex_grow(const css_computed_style *style, css_fixed
 #define FLEX_SHRINK_MASK 0x400000
 static inline uint8_t get_flex_shrink_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_SHRINK_INDEX];
 	bits &= FLEX_SHRINK_MASK;
 	bits >>= FLEX_SHRINK_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_flex_shrink(const css_computed_style *style,
 		css_fixed *fixed)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_SHRINK_INDEX];
 	bits &= FLEX_SHRINK_MASK;
 	bits >>= FLEX_SHRINK_SHIFT;
 	
 	/* 1bit: t : type */
-	if ((bits & 0x1) == CSS_FLEX_SHRINK_SET) {
+	type = bits & 0x1;
+	if (type == CSS_FLEX_SHRINK_SET) {
 		*fixed = style->i.flex_shrink;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef FLEX_SHRINK_INDEX
 #undef FLEX_SHRINK_SHIFT
@@ -1483,22 +1685,26 @@ static inline uint8_t get_flex_shrink(const css_computed_style *style,
 #define FLEX_WRAP_MASK 0x30000000
 static inline uint8_t get_flex_wrap_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_WRAP_INDEX];
 	bits &= FLEX_WRAP_MASK;
 	bits >>= FLEX_WRAP_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_flex_wrap(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLEX_WRAP_INDEX];
 	bits &= FLEX_WRAP_MASK;
 	bits >>= FLEX_WRAP_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef FLEX_WRAP_INDEX
 #undef FLEX_WRAP_SHIFT
@@ -1509,22 +1715,26 @@ static inline uint8_t get_flex_wrap(const css_computed_style *style)
 #define FLOAT_MASK 0xc0000000
 static inline uint8_t get_float_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLOAT_INDEX];
 	bits &= FLOAT_MASK;
 	bits >>= FLOAT_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_float(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FLOAT_INDEX];
 	bits &= FLOAT_MASK;
 	bits >>= FLOAT_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef FLOAT_INDEX
 #undef FLOAT_SHIFT
@@ -1535,24 +1745,28 @@ static inline uint8_t get_float(const css_computed_style *style)
 #define FONT_FAMILY_MASK 0x380
 static inline uint8_t get_font_family_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_FAMILY_INDEX];
 	bits &= FONT_FAMILY_MASK;
 	bits >>= FONT_FAMILY_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_font_family(const css_computed_style *style,
 		lwc_string ***string_arr)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_FAMILY_INDEX];
 	bits &= FONT_FAMILY_MASK;
 	bits >>= FONT_FAMILY_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	*string_arr = style->font_family;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef FONT_FAMILY_INDEX
 #undef FONT_FAMILY_SHIFT
@@ -1563,27 +1777,31 @@ static inline uint8_t get_font_family(const css_computed_style *style,
 #define FONT_SIZE_MASK 0xff800000
 static inline uint8_t get_font_size_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_SIZE_INDEX];
 	bits &= FONT_SIZE_MASK;
 	bits >>= FONT_SIZE_SHIFT;
 	
 	/* 9bits: uuuuutttt : unit | type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_font_size(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_SIZE_INDEX];
 	bits &= FONT_SIZE_MASK;
 	bits >>= FONT_SIZE_SHIFT;
 	
 	/* 9bits: uuuuutttt : unit | type */
-	if ((bits & 0xf) == CSS_FONT_SIZE_DIMENSION) {
+	type = bits & 0xf;
+	if (type == CSS_FONT_SIZE_DIMENSION) {
 		*length = style->i.font_size;
 		*unit = bits >> 4;
 	}
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef FONT_SIZE_INDEX
 #undef FONT_SIZE_SHIFT
@@ -1594,22 +1812,26 @@ static inline uint8_t get_font_size(const css_computed_style *style, css_fixed
 #define FONT_STYLE_MASK 0x3
 static inline uint8_t get_font_style_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_STYLE_INDEX];
 	bits &= FONT_STYLE_MASK;
 	bits >>= FONT_STYLE_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_font_style(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_STYLE_INDEX];
 	bits &= FONT_STYLE_MASK;
 	bits >>= FONT_STYLE_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef FONT_STYLE_INDEX
 #undef FONT_STYLE_SHIFT
@@ -1620,22 +1842,26 @@ static inline uint8_t get_font_style(const css_computed_style *style)
 #define FONT_VARIANT_MASK 0xc
 static inline uint8_t get_font_variant_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_VARIANT_INDEX];
 	bits &= FONT_VARIANT_MASK;
 	bits >>= FONT_VARIANT_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_font_variant(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_VARIANT_INDEX];
 	bits &= FONT_VARIANT_MASK;
 	bits >>= FONT_VARIANT_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef FONT_VARIANT_INDEX
 #undef FONT_VARIANT_SHIFT
@@ -1646,22 +1872,26 @@ static inline uint8_t get_font_variant(const css_computed_style *style)
 #define FONT_WEIGHT_MASK 0xf
 static inline uint8_t get_font_weight_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_WEIGHT_INDEX];
 	bits &= FONT_WEIGHT_MASK;
 	bits >>= FONT_WEIGHT_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_font_weight(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[FONT_WEIGHT_INDEX];
 	bits &= FONT_WEIGHT_MASK;
 	bits >>= FONT_WEIGHT_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef FONT_WEIGHT_INDEX
 #undef FONT_WEIGHT_SHIFT
@@ -1672,27 +1902,31 @@ static inline uint8_t get_font_weight(const css_computed_style *style)
 #define HEIGHT_MASK 0x3f800
 static inline uint8_t get_height_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[HEIGHT_INDEX];
 	bits &= HEIGHT_MASK;
 	bits >>= HEIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_height(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[HEIGHT_INDEX];
 	bits &= HEIGHT_MASK;
 	bits >>= HEIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_HEIGHT_SET) {
+	type = bits & 0x3;
+	if (type == CSS_HEIGHT_SET) {
 		*length = style->i.height;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef HEIGHT_INDEX
 #undef HEIGHT_SHIFT
@@ -1703,22 +1937,26 @@ static inline uint8_t get_height(const css_computed_style *style, css_fixed
 #define JUSTIFY_CONTENT_MASK 0x1c00
 static inline uint8_t get_justify_content_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[JUSTIFY_CONTENT_INDEX];
 	bits &= JUSTIFY_CONTENT_MASK;
 	bits >>= JUSTIFY_CONTENT_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_justify_content(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[JUSTIFY_CONTENT_INDEX];
 	bits &= JUSTIFY_CONTENT_MASK;
 	bits >>= JUSTIFY_CONTENT_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef JUSTIFY_CONTENT_INDEX
 #undef JUSTIFY_CONTENT_SHIFT
@@ -1729,27 +1967,31 @@ static inline uint8_t get_justify_content(const css_computed_style *style)
 #define LEFT_MASK 0x1fc0000
 static inline uint8_t get_left_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LEFT_INDEX];
 	bits &= LEFT_MASK;
 	bits >>= LEFT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_left(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LEFT_INDEX];
 	bits &= LEFT_MASK;
 	bits >>= LEFT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_LEFT_SET) {
+	type = bits & 0x3;
+	if (type == CSS_LEFT_SET) {
 		*length = style->i.left;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef LEFT_INDEX
 #undef LEFT_SHIFT
@@ -1760,27 +2002,31 @@ static inline uint8_t get_left(const css_computed_style *style, css_fixed
 #define LETTER_SPACING_MASK 0xfe000000
 static inline uint8_t get_letter_spacing_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LETTER_SPACING_INDEX];
 	bits &= LETTER_SPACING_MASK;
 	bits >>= LETTER_SPACING_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_letter_spacing(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LETTER_SPACING_INDEX];
 	bits &= LETTER_SPACING_MASK;
 	bits >>= LETTER_SPACING_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_LETTER_SPACING_SET) {
+	type = bits & 0x3;
+	if (type == CSS_LETTER_SPACING_SET) {
 		*length = style->i.letter_spacing;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef LETTER_SPACING_INDEX
 #undef LETTER_SPACING_SHIFT
@@ -1791,12 +2037,14 @@ static inline uint8_t get_letter_spacing(const css_computed_style *style,
 #define LINE_HEIGHT_MASK 0x7f0
 static inline uint8_t get_line_height_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LINE_HEIGHT_INDEX];
 	bits &= LINE_HEIGHT_MASK;
 	bits >>= LINE_HEIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_line_height(
 		const css_computed_style *style,
@@ -1827,24 +2075,28 @@ static inline uint8_t get_line_height(
 #define LIST_STYLE_IMAGE_MASK 0x800000
 static inline uint8_t get_list_style_image_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LIST_STYLE_IMAGE_INDEX];
 	bits &= LIST_STYLE_IMAGE_MASK;
 	bits >>= LIST_STYLE_IMAGE_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_list_style_image(const css_computed_style *style,
 		lwc_string **string)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LIST_STYLE_IMAGE_INDEX];
 	bits &= LIST_STYLE_IMAGE_MASK;
 	bits >>= LIST_STYLE_IMAGE_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*string = style->i.list_style_image;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef LIST_STYLE_IMAGE_INDEX
 #undef LIST_STYLE_IMAGE_SHIFT
@@ -1856,22 +2108,26 @@ static inline uint8_t get_list_style_image(const css_computed_style *style,
 static inline uint8_t get_list_style_position_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LIST_STYLE_POSITION_INDEX];
 	bits &= LIST_STYLE_POSITION_MASK;
 	bits >>= LIST_STYLE_POSITION_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_list_style_position(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LIST_STYLE_POSITION_INDEX];
 	bits &= LIST_STYLE_POSITION_MASK;
 	bits >>= LIST_STYLE_POSITION_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef LIST_STYLE_POSITION_INDEX
 #undef LIST_STYLE_POSITION_SHIFT
@@ -1882,22 +2138,26 @@ static inline uint8_t get_list_style_position(const css_computed_style *style)
 #define LIST_STYLE_TYPE_MASK 0x3f00
 static inline uint8_t get_list_style_type_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LIST_STYLE_TYPE_INDEX];
 	bits &= LIST_STYLE_TYPE_MASK;
 	bits >>= LIST_STYLE_TYPE_SHIFT;
 	
 	/* 6bits: tttttt : type */
-	return (bits & 0x3f);
+	type = bits & 0x3f;
+	return type;
 }
 static inline uint8_t get_list_style_type(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[LIST_STYLE_TYPE_INDEX];
 	bits &= LIST_STYLE_TYPE_MASK;
 	bits >>= LIST_STYLE_TYPE_SHIFT;
 	
 	/* 6bits: tttttt : type */
+	type = bits & 0x3f;
 	
-	return (bits & 0x3f);
+	return type;
 }
 #undef LIST_STYLE_TYPE_INDEX
 #undef LIST_STYLE_TYPE_SHIFT
@@ -1908,27 +2168,31 @@ static inline uint8_t get_list_style_type(const css_computed_style *style)
 #define MARGIN_BOTTOM_MASK 0x3f800
 static inline uint8_t get_margin_bottom_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_BOTTOM_INDEX];
 	bits &= MARGIN_BOTTOM_MASK;
 	bits >>= MARGIN_BOTTOM_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_margin_bottom(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_BOTTOM_INDEX];
 	bits &= MARGIN_BOTTOM_MASK;
 	bits >>= MARGIN_BOTTOM_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MARGIN_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_bottom;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MARGIN_BOTTOM_INDEX
 #undef MARGIN_BOTTOM_SHIFT
@@ -1939,27 +2203,31 @@ static inline uint8_t get_margin_bottom(const css_computed_style *style,
 #define MARGIN_LEFT_MASK 0x1fc0000
 static inline uint8_t get_margin_left_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_LEFT_INDEX];
 	bits &= MARGIN_LEFT_MASK;
 	bits >>= MARGIN_LEFT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_margin_left(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_LEFT_INDEX];
 	bits &= MARGIN_LEFT_MASK;
 	bits >>= MARGIN_LEFT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MARGIN_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_left;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MARGIN_LEFT_INDEX
 #undef MARGIN_LEFT_SHIFT
@@ -1970,27 +2238,31 @@ static inline uint8_t get_margin_left(const css_computed_style *style,
 #define MARGIN_RIGHT_MASK 0xfe000000
 static inline uint8_t get_margin_right_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_RIGHT_INDEX];
 	bits &= MARGIN_RIGHT_MASK;
 	bits >>= MARGIN_RIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_margin_right(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_RIGHT_INDEX];
 	bits &= MARGIN_RIGHT_MASK;
 	bits >>= MARGIN_RIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MARGIN_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_right;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MARGIN_RIGHT_INDEX
 #undef MARGIN_RIGHT_SHIFT
@@ -2001,27 +2273,31 @@ static inline uint8_t get_margin_right(const css_computed_style *style,
 #define MARGIN_TOP_MASK 0x7f0
 static inline uint8_t get_margin_top_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_TOP_INDEX];
 	bits &= MARGIN_TOP_MASK;
 	bits >>= MARGIN_TOP_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_margin_top(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MARGIN_TOP_INDEX];
 	bits &= MARGIN_TOP_MASK;
 	bits >>= MARGIN_TOP_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MARGIN_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MARGIN_SET) {
 		*length = style->i.margin_top;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MARGIN_TOP_INDEX
 #undef MARGIN_TOP_SHIFT
@@ -2032,27 +2308,31 @@ static inline uint8_t get_margin_top(const css_computed_style *style, css_fixed
 #define MAX_HEIGHT_MASK 0x3f800
 static inline uint8_t get_max_height_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MAX_HEIGHT_INDEX];
 	bits &= MAX_HEIGHT_MASK;
 	bits >>= MAX_HEIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_max_height(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MAX_HEIGHT_INDEX];
 	bits &= MAX_HEIGHT_MASK;
 	bits >>= MAX_HEIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MAX_HEIGHT_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MAX_HEIGHT_SET) {
 		*length = style->i.max_height;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MAX_HEIGHT_INDEX
 #undef MAX_HEIGHT_SHIFT
@@ -2063,27 +2343,31 @@ static inline uint8_t get_max_height(const css_computed_style *style, css_fixed
 #define MAX_WIDTH_MASK 0x1fc0000
 static inline uint8_t get_max_width_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MAX_WIDTH_INDEX];
 	bits &= MAX_WIDTH_MASK;
 	bits >>= MAX_WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_max_width(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MAX_WIDTH_INDEX];
 	bits &= MAX_WIDTH_MASK;
 	bits >>= MAX_WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MAX_WIDTH_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MAX_WIDTH_SET) {
 		*length = style->i.max_width;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MAX_WIDTH_INDEX
 #undef MAX_WIDTH_SHIFT
@@ -2094,27 +2378,31 @@ static inline uint8_t get_max_width(const css_computed_style *style, css_fixed
 #define MIN_HEIGHT_MASK 0xfe000000
 static inline uint8_t get_min_height_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MIN_HEIGHT_INDEX];
 	bits &= MIN_HEIGHT_MASK;
 	bits >>= MIN_HEIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_min_height(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MIN_HEIGHT_INDEX];
 	bits &= MIN_HEIGHT_MASK;
 	bits >>= MIN_HEIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MIN_HEIGHT_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MIN_HEIGHT_SET) {
 		*length = style->i.min_height;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MIN_HEIGHT_INDEX
 #undef MIN_HEIGHT_SHIFT
@@ -2125,27 +2413,31 @@ static inline uint8_t get_min_height(const css_computed_style *style, css_fixed
 #define MIN_WIDTH_MASK 0x7f0
 static inline uint8_t get_min_width_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MIN_WIDTH_INDEX];
 	bits &= MIN_WIDTH_MASK;
 	bits >>= MIN_WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_min_width(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[MIN_WIDTH_INDEX];
 	bits &= MIN_WIDTH_MASK;
 	bits >>= MIN_WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_MIN_WIDTH_SET) {
+	type = bits & 0x3;
+	if (type == CSS_MIN_WIDTH_SET) {
 		*length = style->i.min_width;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef MIN_WIDTH_INDEX
 #undef MIN_WIDTH_SHIFT
@@ -2156,26 +2448,30 @@ static inline uint8_t get_min_width(const css_computed_style *style, css_fixed
 #define OPACITY_MASK 0x1000000
 static inline uint8_t get_opacity_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OPACITY_INDEX];
 	bits &= OPACITY_MASK;
 	bits >>= OPACITY_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_opacity(const css_computed_style *style, css_fixed
 		*fixed)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OPACITY_INDEX];
 	bits &= OPACITY_MASK;
 	bits >>= OPACITY_SHIFT;
 	
 	/* 1bit: t : type */
-	if ((bits & 0x1) == CSS_OPACITY_SET) {
+	type = bits & 0x1;
+	if (type == CSS_OPACITY_SET) {
 		*fixed = style->i.opacity;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef OPACITY_INDEX
 #undef OPACITY_SHIFT
@@ -2186,26 +2482,30 @@ static inline uint8_t get_opacity(const css_computed_style *style, css_fixed
 #define ORDER_MASK 0x2000000
 static inline uint8_t get_order_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ORDER_INDEX];
 	bits &= ORDER_MASK;
 	bits >>= ORDER_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_order(const css_computed_style *style, int32_t
 		*integer)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ORDER_INDEX];
 	bits &= ORDER_MASK;
 	bits >>= ORDER_SHIFT;
 	
 	/* 1bit: t : type */
-	if ((bits & 0x1) == CSS_ORDER_SET) {
+	type = bits & 0x1;
+	if (type == CSS_ORDER_SET) {
 		*integer = style->i.order;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef ORDER_INDEX
 #undef ORDER_SHIFT
@@ -2216,24 +2516,28 @@ static inline uint8_t get_order(const css_computed_style *style, int32_t
 #define ORPHANS_MASK 0x4000000
 static inline uint8_t get_orphans_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ORPHANS_INDEX];
 	bits &= ORPHANS_MASK;
 	bits >>= ORPHANS_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_orphans(const css_computed_style *style, int32_t
 		*integer)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[ORPHANS_INDEX];
 	bits &= ORPHANS_MASK;
 	bits >>= ORPHANS_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*integer = style->i.orphans;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef ORPHANS_INDEX
 #undef ORPHANS_SHIFT
@@ -2244,26 +2548,30 @@ static inline uint8_t get_orphans(const css_computed_style *style, int32_t
 #define OUTLINE_COLOR_MASK 0xc0
 static inline uint8_t get_outline_color_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OUTLINE_COLOR_INDEX];
 	bits &= OUTLINE_COLOR_MASK;
 	bits >>= OUTLINE_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_outline_color(const css_computed_style *style,
 		css_color *color)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OUTLINE_COLOR_INDEX];
 	bits &= OUTLINE_COLOR_MASK;
 	bits >>= OUTLINE_COLOR_SHIFT;
 	
 	/* 2bits: tt : type */
-	if ((bits & 0x3) == CSS_OUTLINE_COLOR_COLOR) {
+	type = bits & 0x3;
+	if (type == CSS_OUTLINE_COLOR_COLOR) {
 		*color = style->i.outline_color;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef OUTLINE_COLOR_INDEX
 #undef OUTLINE_COLOR_SHIFT
@@ -2274,22 +2582,26 @@ static inline uint8_t get_outline_color(const css_computed_style *style,
 #define OUTLINE_STYLE_MASK 0xf
 static inline uint8_t get_outline_style_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OUTLINE_STYLE_INDEX];
 	bits &= OUTLINE_STYLE_MASK;
 	bits >>= OUTLINE_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_outline_style(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OUTLINE_STYLE_INDEX];
 	bits &= OUTLINE_STYLE_MASK;
 	bits >>= OUTLINE_STYLE_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef OUTLINE_STYLE_INDEX
 #undef OUTLINE_STYLE_SHIFT
@@ -2300,27 +2612,31 @@ static inline uint8_t get_outline_style(const css_computed_style *style)
 #define OUTLINE_WIDTH_MASK 0x7f8000
 static inline uint8_t get_outline_width_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OUTLINE_WIDTH_INDEX];
 	bits &= OUTLINE_WIDTH_MASK;
 	bits >>= OUTLINE_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_outline_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OUTLINE_WIDTH_INDEX];
 	bits &= OUTLINE_WIDTH_MASK;
 	bits >>= OUTLINE_WIDTH_SHIFT;
 	
 	/* 8bits: uuuuuttt : unit | type */
-	if ((bits & 0x7) == CSS_OUTLINE_WIDTH_WIDTH) {
+	type = bits & 0x7;
+	if (type == CSS_OUTLINE_WIDTH_WIDTH) {
 		*length = style->i.outline_width;
 		*unit = bits >> 3;
 	}
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef OUTLINE_WIDTH_INDEX
 #undef OUTLINE_WIDTH_SHIFT
@@ -2331,22 +2647,26 @@ static inline uint8_t get_outline_width(const css_computed_style *style,
 #define OVERFLOW_X_MASK 0xe000
 static inline uint8_t get_overflow_x_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OVERFLOW_X_INDEX];
 	bits &= OVERFLOW_X_MASK;
 	bits >>= OVERFLOW_X_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_overflow_x(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OVERFLOW_X_INDEX];
 	bits &= OVERFLOW_X_MASK;
 	bits >>= OVERFLOW_X_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef OVERFLOW_X_INDEX
 #undef OVERFLOW_X_SHIFT
@@ -2357,22 +2677,26 @@ static inline uint8_t get_overflow_x(const css_computed_style *style)
 #define OVERFLOW_Y_MASK 0x70000
 static inline uint8_t get_overflow_y_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OVERFLOW_Y_INDEX];
 	bits &= OVERFLOW_Y_MASK;
 	bits >>= OVERFLOW_Y_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_overflow_y(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[OVERFLOW_Y_INDEX];
 	bits &= OVERFLOW_Y_MASK;
 	bits >>= OVERFLOW_Y_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef OVERFLOW_Y_INDEX
 #undef OVERFLOW_Y_SHIFT
@@ -2383,27 +2707,31 @@ static inline uint8_t get_overflow_y(const css_computed_style *style)
 #define PADDING_BOTTOM_MASK 0xfc000
 static inline uint8_t get_padding_bottom_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_BOTTOM_INDEX];
 	bits &= PADDING_BOTTOM_MASK;
 	bits >>= PADDING_BOTTOM_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_padding_bottom(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_BOTTOM_INDEX];
 	bits &= PADDING_BOTTOM_MASK;
 	bits >>= PADDING_BOTTOM_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	if ((bits & 0x1) == CSS_PADDING_SET) {
+	type = bits & 0x1;
+	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_bottom;
 		*unit = bits >> 1;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef PADDING_BOTTOM_INDEX
 #undef PADDING_BOTTOM_SHIFT
@@ -2414,27 +2742,31 @@ static inline uint8_t get_padding_bottom(const css_computed_style *style,
 #define PADDING_LEFT_MASK 0x3f00000
 static inline uint8_t get_padding_left_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_LEFT_INDEX];
 	bits &= PADDING_LEFT_MASK;
 	bits >>= PADDING_LEFT_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_padding_left(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_LEFT_INDEX];
 	bits &= PADDING_LEFT_MASK;
 	bits >>= PADDING_LEFT_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	if ((bits & 0x1) == CSS_PADDING_SET) {
+	type = bits & 0x1;
+	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_left;
 		*unit = bits >> 1;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef PADDING_LEFT_INDEX
 #undef PADDING_LEFT_SHIFT
@@ -2445,27 +2777,31 @@ static inline uint8_t get_padding_left(const css_computed_style *style,
 #define PADDING_RIGHT_MASK 0xfc000000
 static inline uint8_t get_padding_right_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_RIGHT_INDEX];
 	bits &= PADDING_RIGHT_MASK;
 	bits >>= PADDING_RIGHT_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_padding_right(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_RIGHT_INDEX];
 	bits &= PADDING_RIGHT_MASK;
 	bits >>= PADDING_RIGHT_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	if ((bits & 0x1) == CSS_PADDING_SET) {
+	type = bits & 0x1;
+	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_right;
 		*unit = bits >> 1;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef PADDING_RIGHT_INDEX
 #undef PADDING_RIGHT_SHIFT
@@ -2476,27 +2812,31 @@ static inline uint8_t get_padding_right(const css_computed_style *style,
 #define PADDING_TOP_MASK 0x7e0
 static inline uint8_t get_padding_top_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_TOP_INDEX];
 	bits &= PADDING_TOP_MASK;
 	bits >>= PADDING_TOP_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_padding_top(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PADDING_TOP_INDEX];
 	bits &= PADDING_TOP_MASK;
 	bits >>= PADDING_TOP_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	if ((bits & 0x1) == CSS_PADDING_SET) {
+	type = bits & 0x1;
+	if (type == CSS_PADDING_SET) {
 		*length = style->i.padding_top;
 		*unit = bits >> 1;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef PADDING_TOP_INDEX
 #undef PADDING_TOP_SHIFT
@@ -2507,22 +2847,26 @@ static inline uint8_t get_padding_top(const css_computed_style *style,
 #define PAGE_BREAK_AFTER_MASK 0x380000
 static inline uint8_t get_page_break_after_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PAGE_BREAK_AFTER_INDEX];
 	bits &= PAGE_BREAK_AFTER_MASK;
 	bits >>= PAGE_BREAK_AFTER_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_page_break_after(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PAGE_BREAK_AFTER_INDEX];
 	bits &= PAGE_BREAK_AFTER_MASK;
 	bits >>= PAGE_BREAK_AFTER_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef PAGE_BREAK_AFTER_INDEX
 #undef PAGE_BREAK_AFTER_SHIFT
@@ -2534,22 +2878,26 @@ static inline uint8_t get_page_break_after(const css_computed_style *style)
 static inline uint8_t get_page_break_before_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PAGE_BREAK_BEFORE_INDEX];
 	bits &= PAGE_BREAK_BEFORE_MASK;
 	bits >>= PAGE_BREAK_BEFORE_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_page_break_before(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PAGE_BREAK_BEFORE_INDEX];
 	bits &= PAGE_BREAK_BEFORE_MASK;
 	bits >>= PAGE_BREAK_BEFORE_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef PAGE_BREAK_BEFORE_INDEX
 #undef PAGE_BREAK_BEFORE_SHIFT
@@ -2561,22 +2909,26 @@ static inline uint8_t get_page_break_before(const css_computed_style *style)
 static inline uint8_t get_page_break_inside_bits(const css_computed_style
 		*style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PAGE_BREAK_INSIDE_INDEX];
 	bits &= PAGE_BREAK_INSIDE_MASK;
 	bits >>= PAGE_BREAK_INSIDE_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_page_break_inside(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[PAGE_BREAK_INSIDE_INDEX];
 	bits &= PAGE_BREAK_INSIDE_MASK;
 	bits >>= PAGE_BREAK_INSIDE_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef PAGE_BREAK_INSIDE_INDEX
 #undef PAGE_BREAK_INSIDE_SHIFT
@@ -2587,22 +2939,26 @@ static inline uint8_t get_page_break_inside(const css_computed_style *style)
 #define POSITION_MASK 0xe000000
 static inline uint8_t get_position_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[POSITION_INDEX];
 	bits &= POSITION_MASK;
 	bits >>= POSITION_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_position(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[POSITION_INDEX];
 	bits &= POSITION_MASK;
 	bits >>= POSITION_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef POSITION_INDEX
 #undef POSITION_SHIFT
@@ -2613,24 +2969,28 @@ static inline uint8_t get_position(const css_computed_style *style)
 #define QUOTES_MASK 0x8000000
 static inline uint8_t get_quotes_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[QUOTES_INDEX];
 	bits &= QUOTES_MASK;
 	bits >>= QUOTES_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_quotes(const css_computed_style *style, lwc_string
 		***string_arr)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[QUOTES_INDEX];
 	bits &= QUOTES_MASK;
 	bits >>= QUOTES_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*string_arr = style->quotes;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef QUOTES_INDEX
 #undef QUOTES_SHIFT
@@ -2641,27 +3001,31 @@ static inline uint8_t get_quotes(const css_computed_style *style, lwc_string
 #define RIGHT_MASK 0x3f800
 static inline uint8_t get_right_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[RIGHT_INDEX];
 	bits &= RIGHT_MASK;
 	bits >>= RIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_right(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[RIGHT_INDEX];
 	bits &= RIGHT_MASK;
 	bits >>= RIGHT_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_RIGHT_SET) {
+	type = bits & 0x3;
+	if (type == CSS_RIGHT_SET) {
 		*length = style->i.right;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef RIGHT_INDEX
 #undef RIGHT_SHIFT
@@ -2672,26 +3036,30 @@ static inline uint8_t get_right(const css_computed_style *style, css_fixed
 #define STROKE_OPACITY_MASK 0x1
 static inline uint8_t get_stroke_opacity_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[STROKE_OPACITY_INDEX];
 	bits &= STROKE_OPACITY_MASK;
 	bits >>= STROKE_OPACITY_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_stroke_opacity(const css_computed_style *style,
 		css_fixed *fixed)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[STROKE_OPACITY_INDEX];
 	bits &= STROKE_OPACITY_MASK;
 	bits >>= STROKE_OPACITY_SHIFT;
 	
 	/* 1bit: t : type */
-	if ((bits & 0x1) == CSS_STROKE_OPACITY_SET) {
+	type = bits & 0x1;
+	if (type == CSS_STROKE_OPACITY_SET) {
 		*fixed = style->i.stroke_opacity;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef STROKE_OPACITY_INDEX
 #undef STROKE_OPACITY_SHIFT
@@ -2702,22 +3070,26 @@ static inline uint8_t get_stroke_opacity(const css_computed_style *style,
 #define TABLE_LAYOUT_MASK 0xc00
 static inline uint8_t get_table_layout_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TABLE_LAYOUT_INDEX];
 	bits &= TABLE_LAYOUT_MASK;
 	bits >>= TABLE_LAYOUT_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_table_layout(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TABLE_LAYOUT_INDEX];
 	bits &= TABLE_LAYOUT_MASK;
 	bits >>= TABLE_LAYOUT_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef TABLE_LAYOUT_INDEX
 #undef TABLE_LAYOUT_SHIFT
@@ -2728,22 +3100,26 @@ static inline uint8_t get_table_layout(const css_computed_style *style)
 #define TEXT_ALIGN_MASK 0xf
 static inline uint8_t get_text_align_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_ALIGN_INDEX];
 	bits &= TEXT_ALIGN_MASK;
 	bits >>= TEXT_ALIGN_SHIFT;
 	
 	/* 4bits: tttt : type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_text_align(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_ALIGN_INDEX];
 	bits &= TEXT_ALIGN_MASK;
 	bits >>= TEXT_ALIGN_SHIFT;
 	
 	/* 4bits: tttt : type */
+	type = bits & 0xf;
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef TEXT_ALIGN_INDEX
 #undef TEXT_ALIGN_SHIFT
@@ -2754,22 +3130,26 @@ static inline uint8_t get_text_align(const css_computed_style *style)
 #define TEXT_DECORATION_MASK 0x1f
 static inline uint8_t get_text_decoration_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_DECORATION_INDEX];
 	bits &= TEXT_DECORATION_MASK;
 	bits >>= TEXT_DECORATION_SHIFT;
 	
 	/* 5bits: ttttt : type */
-	return (bits & 0x1f);
+	type = bits & 0x1f;
+	return type;
 }
 static inline uint8_t get_text_decoration(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_DECORATION_INDEX];
 	bits &= TEXT_DECORATION_MASK;
 	bits >>= TEXT_DECORATION_SHIFT;
 	
 	/* 5bits: ttttt : type */
+	type = bits & 0x1f;
 	
-	return (bits & 0x1f);
+	return type;
 }
 #undef TEXT_DECORATION_INDEX
 #undef TEXT_DECORATION_SHIFT
@@ -2780,27 +3160,31 @@ static inline uint8_t get_text_decoration(const css_computed_style *style)
 #define TEXT_INDENT_MASK 0x3f
 static inline uint8_t get_text_indent_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_INDENT_INDEX];
 	bits &= TEXT_INDENT_MASK;
 	bits >>= TEXT_INDENT_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_text_indent(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_INDENT_INDEX];
 	bits &= TEXT_INDENT_MASK;
 	bits >>= TEXT_INDENT_SHIFT;
 	
 	/* 6bits: uuuuut : unit | type */
-	if ((bits & 0x1) == CSS_TEXT_INDENT_SET) {
+	type = bits & 0x1;
+	if (type == CSS_TEXT_INDENT_SET) {
 		*length = style->i.text_indent;
 		*unit = bits >> 1;
 	}
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef TEXT_INDENT_INDEX
 #undef TEXT_INDENT_SHIFT
@@ -2811,22 +3195,26 @@ static inline uint8_t get_text_indent(const css_computed_style *style,
 #define TEXT_TRANSFORM_MASK 0x7
 static inline uint8_t get_text_transform_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_TRANSFORM_INDEX];
 	bits &= TEXT_TRANSFORM_MASK;
 	bits >>= TEXT_TRANSFORM_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_text_transform(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TEXT_TRANSFORM_INDEX];
 	bits &= TEXT_TRANSFORM_MASK;
 	bits >>= TEXT_TRANSFORM_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef TEXT_TRANSFORM_INDEX
 #undef TEXT_TRANSFORM_SHIFT
@@ -2837,27 +3225,31 @@ static inline uint8_t get_text_transform(const css_computed_style *style)
 #define TOP_MASK 0x1fc0000
 static inline uint8_t get_top_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TOP_INDEX];
 	bits &= TOP_MASK;
 	bits >>= TOP_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_top(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[TOP_INDEX];
 	bits &= TOP_MASK;
 	bits >>= TOP_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_TOP_SET) {
+	type = bits & 0x3;
+	if (type == CSS_TOP_SET) {
 		*length = style->i.top;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef TOP_INDEX
 #undef TOP_SHIFT
@@ -2868,22 +3260,26 @@ static inline uint8_t get_top(const css_computed_style *style, css_fixed
 #define UNICODE_BIDI_MASK 0x3000
 static inline uint8_t get_unicode_bidi_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[UNICODE_BIDI_INDEX];
 	bits &= UNICODE_BIDI_MASK;
 	bits >>= UNICODE_BIDI_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_unicode_bidi(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[UNICODE_BIDI_INDEX];
 	bits &= UNICODE_BIDI_MASK;
 	bits >>= UNICODE_BIDI_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef UNICODE_BIDI_INDEX
 #undef UNICODE_BIDI_SHIFT
@@ -2894,27 +3290,31 @@ static inline uint8_t get_unicode_bidi(const css_computed_style *style)
 #define VERTICAL_ALIGN_MASK 0x3fe
 static inline uint8_t get_vertical_align_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[VERTICAL_ALIGN_INDEX];
 	bits &= VERTICAL_ALIGN_MASK;
 	bits >>= VERTICAL_ALIGN_SHIFT;
 	
 	/* 9bits: uuuuutttt : unit | type */
-	return (bits & 0xf);
+	type = bits & 0xf;
+	return type;
 }
 static inline uint8_t get_vertical_align(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[VERTICAL_ALIGN_INDEX];
 	bits &= VERTICAL_ALIGN_MASK;
 	bits >>= VERTICAL_ALIGN_SHIFT;
 	
 	/* 9bits: uuuuutttt : unit | type */
-	if ((bits & 0xf) == CSS_VERTICAL_ALIGN_SET) {
+	type = bits & 0xf;
+	if (type == CSS_VERTICAL_ALIGN_SET) {
 		*length = style->i.vertical_align;
 		*unit = bits >> 4;
 	}
 	
-	return (bits & 0xf);
+	return type;
 }
 #undef VERTICAL_ALIGN_INDEX
 #undef VERTICAL_ALIGN_SHIFT
@@ -2925,22 +3325,26 @@ static inline uint8_t get_vertical_align(const css_computed_style *style,
 #define VISIBILITY_MASK 0xc000
 static inline uint8_t get_visibility_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[VISIBILITY_INDEX];
 	bits &= VISIBILITY_MASK;
 	bits >>= VISIBILITY_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_visibility(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[VISIBILITY_INDEX];
 	bits &= VISIBILITY_MASK;
 	bits >>= VISIBILITY_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef VISIBILITY_INDEX
 #undef VISIBILITY_SHIFT
@@ -2951,22 +3355,26 @@ static inline uint8_t get_visibility(const css_computed_style *style)
 #define WHITE_SPACE_MASK 0x7
 static inline uint8_t get_white_space_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WHITE_SPACE_INDEX];
 	bits &= WHITE_SPACE_MASK;
 	bits >>= WHITE_SPACE_SHIFT;
 	
 	/* 3bits: ttt : type */
-	return (bits & 0x7);
+	type = bits & 0x7;
+	return type;
 }
 static inline uint8_t get_white_space(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WHITE_SPACE_INDEX];
 	bits &= WHITE_SPACE_MASK;
 	bits >>= WHITE_SPACE_SHIFT;
 	
 	/* 3bits: ttt : type */
+	type = bits & 0x7;
 	
-	return (bits & 0x7);
+	return type;
 }
 #undef WHITE_SPACE_INDEX
 #undef WHITE_SPACE_SHIFT
@@ -2977,24 +3385,28 @@ static inline uint8_t get_white_space(const css_computed_style *style)
 #define WIDOWS_MASK 0x1
 static inline uint8_t get_widows_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WIDOWS_INDEX];
 	bits &= WIDOWS_MASK;
 	bits >>= WIDOWS_SHIFT;
 	
 	/* 1bit: t : type */
-	return (bits & 0x1);
+	type = bits & 0x1;
+	return type;
 }
 static inline uint8_t get_widows(const css_computed_style *style, int32_t
 		*integer)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WIDOWS_INDEX];
 	bits &= WIDOWS_MASK;
 	bits >>= WIDOWS_SHIFT;
 	
 	/* 1bit: t : type */
+	type = bits & 0x1;
 	*integer = style->i.widows;
 	
-	return (bits & 0x1);
+	return type;
 }
 #undef WIDOWS_INDEX
 #undef WIDOWS_SHIFT
@@ -3005,27 +3417,31 @@ static inline uint8_t get_widows(const css_computed_style *style, int32_t
 #define WIDTH_MASK 0xfe000000
 static inline uint8_t get_width_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WIDTH_INDEX];
 	bits &= WIDTH_MASK;
 	bits >>= WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_width(const css_computed_style *style,
 		css_fixed_or_calc *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WIDTH_INDEX];
 	bits &= WIDTH_MASK;
 	bits >>= WIDTH_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_WIDTH_SET) {
+	type = bits & 0x3;
+	if (type == CSS_WIDTH_SET) {
 		*length = style->i.width;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef WIDTH_INDEX
 #undef WIDTH_SHIFT
@@ -3036,27 +3452,31 @@ static inline uint8_t get_width(const css_computed_style *style,
 #define WORD_SPACING_MASK 0x7f
 static inline uint8_t get_word_spacing_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WORD_SPACING_INDEX];
 	bits &= WORD_SPACING_MASK;
 	bits >>= WORD_SPACING_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_word_spacing(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WORD_SPACING_INDEX];
 	bits &= WORD_SPACING_MASK;
 	bits >>= WORD_SPACING_SHIFT;
 	
 	/* 7bits: uuuuutt : unit | type */
-	if ((bits & 0x3) == CSS_WORD_SPACING_SET) {
+	type = bits & 0x3;
+	if (type == CSS_WORD_SPACING_SET) {
 		*length = style->i.word_spacing;
 		*unit = bits >> 2;
 	}
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef WORD_SPACING_INDEX
 #undef WORD_SPACING_SHIFT
@@ -3067,22 +3487,26 @@ static inline uint8_t get_word_spacing(const css_computed_style *style,
 #define WRITING_MODE_MASK 0x30000
 static inline uint8_t get_writing_mode_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WRITING_MODE_INDEX];
 	bits &= WRITING_MODE_MASK;
 	bits >>= WRITING_MODE_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_writing_mode(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[WRITING_MODE_INDEX];
 	bits &= WRITING_MODE_MASK;
 	bits >>= WRITING_MODE_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef WRITING_MODE_INDEX
 #undef WRITING_MODE_SHIFT
@@ -3093,24 +3517,28 @@ static inline uint8_t get_writing_mode(const css_computed_style *style)
 #define Z_INDEX_MASK 0xc0000
 static inline uint8_t get_z_index_bits(const css_computed_style *style)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[Z_INDEX_INDEX];
 	bits &= Z_INDEX_MASK;
 	bits >>= Z_INDEX_SHIFT;
 	
 	/* 2bits: tt : type */
-	return (bits & 0x3);
+	type = bits & 0x3;
+	return type;
 }
 static inline uint8_t get_z_index(const css_computed_style *style, int32_t
 		*integer)
 {
+	uint8_t type;
 	uint32_t bits = style->i.bits[Z_INDEX_INDEX];
 	bits &= Z_INDEX_MASK;
 	bits >>= Z_INDEX_SHIFT;
 	
 	/* 2bits: tt : type */
+	type = bits & 0x3;
 	*integer = style->i.z_index;
 	
-	return (bits & 0x3);
+	return type;
 }
 #undef Z_INDEX_INDEX
 #undef Z_INDEX_SHIFT

--- a/src/select/autogenerated_propset.h
+++ b/src/select/autogenerated_propset.h
@@ -19,11 +19,11 @@ static inline css_error set_align_content(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[ALIGN_CONTENT_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~ALIGN_CONTENT_MASK) | (((uint32_t)type & 0x7) <<
 			ALIGN_CONTENT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef ALIGN_CONTENT_INDEX
@@ -37,11 +37,11 @@ static inline css_error set_align_content(css_computed_style *style, uint8_t
 static inline css_error set_align_items(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[ALIGN_ITEMS_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~ALIGN_ITEMS_MASK) | (((uint32_t)type & 0x7) <<
 			ALIGN_ITEMS_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef ALIGN_ITEMS_INDEX
@@ -55,11 +55,11 @@ static inline css_error set_align_items(css_computed_style *style, uint8_t type)
 static inline css_error set_align_self(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[ALIGN_SELF_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~ALIGN_SELF_MASK) | (((uint32_t)type & 0x7) <<
 			ALIGN_SELF_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef ALIGN_SELF_INDEX
@@ -74,11 +74,11 @@ static inline css_error set_background_attachment(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[BACKGROUND_ATTACHMENT_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BACKGROUND_ATTACHMENT_MASK) | (((uint32_t)type & 0x3)
 			<< BACKGROUND_ATTACHMENT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BACKGROUND_ATTACHMENT_INDEX
@@ -93,13 +93,13 @@ static inline css_error set_background_color(css_computed_style *style, uint8_t
 		type, css_color color)
 {
 	uint32_t *bits = &style->i.bits[BACKGROUND_COLOR_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BACKGROUND_COLOR_MASK) | (((uint32_t)type & 0x3) <<
 			BACKGROUND_COLOR_SHIFT);
-	
+
 	style->i.background_color = color;
-	
+
 	return CSS_OK;
 }
 #undef BACKGROUND_COLOR_INDEX
@@ -114,21 +114,21 @@ static inline css_error set_background_image(css_computed_style *style, uint8_t
 		type, lwc_string *string)
 {
 	uint32_t *bits = &style->i.bits[BACKGROUND_IMAGE_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~BACKGROUND_IMAGE_MASK) | (((uint32_t)type & 0x1) <<
 			BACKGROUND_IMAGE_SHIFT);
-	
+
 	lwc_string *old_string = style->i.background_image;
-	
+
 	if (string != NULL) {
 		style->i.background_image = lwc_string_ref(string);
 	} else {
 		style->i.background_image = NULL;
 	}
-	
+
 	lwc_string_unref(old_string);
-	
+
 	return CSS_OK;
 }
 #undef BACKGROUND_IMAGE_INDEX
@@ -144,16 +144,16 @@ static inline css_error set_background_position(css_computed_style *style,
 		length_b, css_unit unit_b)
 {
 	uint32_t *bits = &style->i.bits[BACKGROUND_POSITION_INDEX];
-	
+
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
 	*bits = (*bits & ~BACKGROUND_POSITION_MASK) | ((((uint32_t)type & 0x1)
 			| (unit_b << 1) | (unit_a << 6)) <<
 			BACKGROUND_POSITION_SHIFT);
-	
+
 	style->i.background_position_a = length_a;
-	
+
 	style->i.background_position_b = length_b;
-	
+
 	return CSS_OK;
 }
 #undef BACKGROUND_POSITION_INDEX
@@ -168,11 +168,11 @@ static inline css_error set_background_repeat(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[BACKGROUND_REPEAT_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~BACKGROUND_REPEAT_MASK) | (((uint32_t)type & 0x7) <<
 			BACKGROUND_REPEAT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BACKGROUND_REPEAT_INDEX
@@ -187,13 +187,13 @@ static inline css_error set_border_bottom_color(css_computed_style *style,
 		uint8_t type, css_color color)
 {
 	uint32_t *bits = &style->i.bits[BORDER_BOTTOM_COLOR_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BORDER_BOTTOM_COLOR_MASK) | (((uint32_t)type & 0x3)
 			<< BORDER_BOTTOM_COLOR_SHIFT);
-	
+
 	style->i.border_bottom_color = color;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_BOTTOM_COLOR_INDEX
@@ -208,11 +208,11 @@ static inline css_error set_border_bottom_style(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[BORDER_BOTTOM_STYLE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~BORDER_BOTTOM_STYLE_MASK) | (((uint32_t)type & 0xf)
 			<< BORDER_BOTTOM_STYLE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BORDER_BOTTOM_STYLE_INDEX
@@ -227,13 +227,13 @@ static inline css_error set_border_bottom_width(css_computed_style *style,
 		uint8_t type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[BORDER_BOTTOM_WIDTH_INDEX];
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	*bits = (*bits & ~BORDER_BOTTOM_WIDTH_MASK) | ((((uint32_t)type & 0x7)
 			| (unit << 3)) << BORDER_BOTTOM_WIDTH_SHIFT);
-	
+
 	style->i.border_bottom_width = length;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_BOTTOM_WIDTH_INDEX
@@ -248,11 +248,11 @@ static inline css_error set_border_collapse(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[BORDER_COLLAPSE_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BORDER_COLLAPSE_MASK) | (((uint32_t)type & 0x3) <<
 			BORDER_COLLAPSE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BORDER_COLLAPSE_INDEX
@@ -267,13 +267,13 @@ static inline css_error set_border_left_color(css_computed_style *style,
 		uint8_t type, css_color color)
 {
 	uint32_t *bits = &style->i.bits[BORDER_LEFT_COLOR_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BORDER_LEFT_COLOR_MASK) | (((uint32_t)type & 0x3) <<
 			BORDER_LEFT_COLOR_SHIFT);
-	
+
 	style->i.border_left_color = color;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_LEFT_COLOR_INDEX
@@ -288,11 +288,11 @@ static inline css_error set_border_left_style(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[BORDER_LEFT_STYLE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~BORDER_LEFT_STYLE_MASK) | (((uint32_t)type & 0xf) <<
 			BORDER_LEFT_STYLE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BORDER_LEFT_STYLE_INDEX
@@ -307,13 +307,13 @@ static inline css_error set_border_left_width(css_computed_style *style,
 		uint8_t type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[BORDER_LEFT_WIDTH_INDEX];
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	*bits = (*bits & ~BORDER_LEFT_WIDTH_MASK) | ((((uint32_t)type & 0x7) | (
 			unit << 3)) << BORDER_LEFT_WIDTH_SHIFT);
-	
+
 	style->i.border_left_width = length;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_LEFT_WIDTH_INDEX
@@ -328,13 +328,13 @@ static inline css_error set_border_right_color(css_computed_style *style,
 		uint8_t type, css_color color)
 {
 	uint32_t *bits = &style->i.bits[BORDER_RIGHT_COLOR_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BORDER_RIGHT_COLOR_MASK) | (((uint32_t)type & 0x3) <<
 			BORDER_RIGHT_COLOR_SHIFT);
-	
+
 	style->i.border_right_color = color;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_RIGHT_COLOR_INDEX
@@ -349,11 +349,11 @@ static inline css_error set_border_right_style(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[BORDER_RIGHT_STYLE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~BORDER_RIGHT_STYLE_MASK) | (((uint32_t)type & 0xf) <<
 			BORDER_RIGHT_STYLE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BORDER_RIGHT_STYLE_INDEX
@@ -368,13 +368,13 @@ static inline css_error set_border_right_width(css_computed_style *style,
 		uint8_t type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[BORDER_RIGHT_WIDTH_INDEX];
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	*bits = (*bits & ~BORDER_RIGHT_WIDTH_MASK) | ((((uint32_t)type & 0x7) |
 			(unit << 3)) << BORDER_RIGHT_WIDTH_SHIFT);
-	
+
 	style->i.border_right_width = length;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_RIGHT_WIDTH_INDEX
@@ -390,15 +390,15 @@ static inline css_error set_border_spacing(css_computed_style *style, uint8_t
 		css_unit unit_b)
 {
 	uint32_t *bits = &style->i.bits[BORDER_SPACING_INDEX];
-	
+
 	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
 	*bits = (*bits & ~BORDER_SPACING_MASK) | ((((uint32_t)type & 0x1) | (
 			unit_b << 1) | (unit_a << 6)) << BORDER_SPACING_SHIFT);
-	
+
 	style->i.border_spacing_a = length_a;
-	
+
 	style->i.border_spacing_b = length_b;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_SPACING_INDEX
@@ -413,13 +413,13 @@ static inline css_error set_border_top_color(css_computed_style *style, uint8_t
 		type, css_color color)
 {
 	uint32_t *bits = &style->i.bits[BORDER_TOP_COLOR_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BORDER_TOP_COLOR_MASK) | (((uint32_t)type & 0x3) <<
 			BORDER_TOP_COLOR_SHIFT);
-	
+
 	style->i.border_top_color = color;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_TOP_COLOR_INDEX
@@ -434,11 +434,11 @@ static inline css_error set_border_top_style(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[BORDER_TOP_STYLE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~BORDER_TOP_STYLE_MASK) | (((uint32_t)type & 0xf) <<
 			BORDER_TOP_STYLE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BORDER_TOP_STYLE_INDEX
@@ -453,13 +453,13 @@ static inline css_error set_border_top_width(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[BORDER_TOP_WIDTH_INDEX];
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	*bits = (*bits & ~BORDER_TOP_WIDTH_MASK) | ((((uint32_t)type & 0x7) | (
 			unit << 3)) << BORDER_TOP_WIDTH_SHIFT);
-	
+
 	style->i.border_top_width = length;
-	
+
 	return CSS_OK;
 }
 #undef BORDER_TOP_WIDTH_INDEX
@@ -474,13 +474,13 @@ static inline css_error set_bottom(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[BOTTOM_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~BOTTOM_MASK) | ((((uint32_t)type & 0x3) | (unit <<
 			2)) << BOTTOM_SHIFT);
-	
+
 	style->i.bottom = length;
-	
+
 	return CSS_OK;
 }
 #undef BOTTOM_INDEX
@@ -494,11 +494,11 @@ static inline css_error set_bottom(css_computed_style *style, uint8_t type,
 static inline css_error set_box_sizing(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[BOX_SIZING_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~BOX_SIZING_MASK) | (((uint32_t)type & 0x3) <<
 			BOX_SIZING_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BOX_SIZING_INDEX
@@ -512,11 +512,11 @@ static inline css_error set_box_sizing(css_computed_style *style, uint8_t type)
 static inline css_error set_break_after(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[BREAK_AFTER_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~BREAK_AFTER_MASK) | (((uint32_t)type & 0xf) <<
 			BREAK_AFTER_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BREAK_AFTER_INDEX
@@ -531,11 +531,11 @@ static inline css_error set_break_before(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[BREAK_BEFORE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~BREAK_BEFORE_MASK) | (((uint32_t)type & 0xf) <<
 			BREAK_BEFORE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BREAK_BEFORE_INDEX
@@ -550,11 +550,11 @@ static inline css_error set_break_inside(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[BREAK_INSIDE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~BREAK_INSIDE_MASK) | (((uint32_t)type & 0xf) <<
 			BREAK_INSIDE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef BREAK_INSIDE_INDEX
@@ -569,11 +569,11 @@ static inline css_error set_caption_side(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[CAPTION_SIDE_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~CAPTION_SIDE_MASK) | (((uint32_t)type & 0x3) <<
 			CAPTION_SIDE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef CAPTION_SIDE_INDEX
@@ -587,10 +587,10 @@ static inline css_error set_caption_side(css_computed_style *style, uint8_t
 static inline css_error set_clear(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[CLEAR_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~CLEAR_MASK) | (((uint32_t)type & 0x7) << CLEAR_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef CLEAR_INDEX
@@ -648,12 +648,12 @@ static inline css_error set_color(css_computed_style *style, uint8_t type,
 		css_color color)
 {
 	uint32_t *bits = &style->i.bits[COLOR_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~COLOR_MASK) | (((uint32_t)type & 0x1) << COLOR_SHIFT);
-	
+
 	style->i.color = color;
-	
+
 	return CSS_OK;
 }
 #undef COLOR_INDEX
@@ -668,13 +668,13 @@ static inline css_error set_column_count(css_computed_style *style, uint8_t
 		type, int32_t integer)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_COUNT_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~COLUMN_COUNT_MASK) | (((uint32_t)type & 0x3) <<
 			COLUMN_COUNT_SHIFT);
-	
+
 	style->i.column_count = integer;
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_COUNT_INDEX
@@ -688,11 +688,11 @@ static inline css_error set_column_count(css_computed_style *style, uint8_t
 static inline css_error set_column_fill(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_FILL_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~COLUMN_FILL_MASK) | (((uint32_t)type & 0x3) <<
 			COLUMN_FILL_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_FILL_INDEX
@@ -707,13 +707,13 @@ static inline css_error set_column_gap(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_GAP_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~COLUMN_GAP_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << COLUMN_GAP_SHIFT);
-	
+
 	style->i.column_gap = length;
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_GAP_INDEX
@@ -728,13 +728,13 @@ static inline css_error set_column_rule_color(css_computed_style *style,
 		uint8_t type, css_color color)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_RULE_COLOR_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~COLUMN_RULE_COLOR_MASK) | (((uint32_t)type & 0x3) <<
 			COLUMN_RULE_COLOR_SHIFT);
-	
+
 	style->i.column_rule_color = color;
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_RULE_COLOR_INDEX
@@ -749,11 +749,11 @@ static inline css_error set_column_rule_style(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_RULE_STYLE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~COLUMN_RULE_STYLE_MASK) | (((uint32_t)type & 0xf) <<
 			COLUMN_RULE_STYLE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_RULE_STYLE_INDEX
@@ -768,13 +768,13 @@ static inline css_error set_column_rule_width(css_computed_style *style,
 		uint8_t type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_RULE_WIDTH_INDEX];
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	*bits = (*bits & ~COLUMN_RULE_WIDTH_MASK) | ((((uint32_t)type & 0x7) | (
 			unit << 3)) << COLUMN_RULE_WIDTH_SHIFT);
-	
+
 	style->i.column_rule_width = length;
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_RULE_WIDTH_INDEX
@@ -788,11 +788,11 @@ static inline css_error set_column_rule_width(css_computed_style *style,
 static inline css_error set_column_span(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_SPAN_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~COLUMN_SPAN_MASK) | (((uint32_t)type & 0x3) <<
 			COLUMN_SPAN_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_SPAN_INDEX
@@ -807,13 +807,13 @@ static inline css_error set_column_width(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[COLUMN_WIDTH_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~COLUMN_WIDTH_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << COLUMN_WIDTH_SHIFT);
-	
+
 	style->i.column_width = length;
-	
+
 	return CSS_OK;
 }
 #undef COLUMN_WIDTH_INDEX
@@ -911,28 +911,28 @@ static inline css_error set_counter_increment(css_computed_style *style,
 		uint8_t type, css_computed_counter *counter_arr)
 {
 	uint32_t *bits = &style->i.bits[COUNTER_INCREMENT_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~COUNTER_INCREMENT_MASK) | (((uint32_t)type & 0x1) <<
 			COUNTER_INCREMENT_SHIFT);
-	
+
 	css_computed_counter *old_counter_arr = style->counter_increment;
 	css_computed_counter *c;
-	
+
 	for (c = counter_arr; c != NULL && c->name != NULL; c++)
 		c->name = lwc_string_ref(c->name);
-	
+
 	style->counter_increment = counter_arr;
-	
+
 	/* Free existing array */
 	if (old_counter_arr != NULL) {
 		for (c = old_counter_arr; c->name != NULL; c++)
 			lwc_string_unref(c->name);
-		
+
 		if (old_counter_arr != counter_arr)
 			free(old_counter_arr);
 	}
-	
+
 	return CSS_OK;
 }
 #undef COUNTER_INCREMENT_INDEX
@@ -947,28 +947,28 @@ static inline css_error set_counter_reset(css_computed_style *style, uint8_t
 		type, css_computed_counter *counter_arr)
 {
 	uint32_t *bits = &style->i.bits[COUNTER_RESET_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~COUNTER_RESET_MASK) | (((uint32_t)type & 0x1) <<
 			COUNTER_RESET_SHIFT);
-	
+
 	css_computed_counter *old_counter_arr = style->counter_reset;
 	css_computed_counter *c;
-	
+
 	for (c = counter_arr; c != NULL && c->name != NULL; c++)
 		c->name = lwc_string_ref(c->name);
-	
+
 	style->counter_reset = counter_arr;
-	
+
 	/* Free existing array */
 	if (old_counter_arr != NULL) {
 		for (c = old_counter_arr; c->name != NULL; c++)
 			lwc_string_unref(c->name);
-		
+
 		if (old_counter_arr != counter_arr)
 			free(old_counter_arr);
 	}
-	
+
 	return CSS_OK;
 }
 #undef COUNTER_RESET_INDEX
@@ -983,28 +983,28 @@ static inline css_error set_cursor(css_computed_style *style, uint8_t type,
 		lwc_string **string_arr)
 {
 	uint32_t *bits = &style->i.bits[CURSOR_INDEX];
-	
+
 	/* 5bits: ttttt : type */
 	*bits = (*bits & ~CURSOR_MASK) | (((uint32_t)type & 0x1f) <<
 			CURSOR_SHIFT);
-	
+
 	lwc_string **old_string_arr = style->cursor;
 	lwc_string **s;
-	
+
 	for (s = string_arr; s != NULL && *s != NULL; s++)
 		*s = lwc_string_ref(*s);
-	
+
 	style->cursor = string_arr;
-	
+
 	/* Free existing array */
 	if (old_string_arr != NULL) {
 		for (s = old_string_arr; *s != NULL; s++)
 			lwc_string_unref(*s);
-		
+
 		if (old_string_arr != string_arr)
 			free(old_string_arr);
 	}
-	
+
 	return CSS_OK;
 }
 #undef CURSOR_INDEX
@@ -1018,11 +1018,11 @@ static inline css_error set_cursor(css_computed_style *style, uint8_t type,
 static inline css_error set_direction(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[DIRECTION_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~DIRECTION_MASK) | (((uint32_t)type & 0x3) <<
 			DIRECTION_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef DIRECTION_INDEX
@@ -1036,11 +1036,11 @@ static inline css_error set_direction(css_computed_style *style, uint8_t type)
 static inline css_error set_display(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[DISPLAY_INDEX];
-	
+
 	/* 5bits: ttttt : type */
 	*bits = (*bits & ~DISPLAY_MASK) | (((uint32_t)type & 0x1f) <<
 			DISPLAY_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef DISPLAY_INDEX
@@ -1054,11 +1054,11 @@ static inline css_error set_display(css_computed_style *style, uint8_t type)
 static inline css_error set_empty_cells(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[EMPTY_CELLS_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~EMPTY_CELLS_MASK) | (((uint32_t)type & 0x3) <<
 			EMPTY_CELLS_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef EMPTY_CELLS_INDEX
@@ -1073,13 +1073,13 @@ static inline css_error set_fill_opacity(css_computed_style *style, uint8_t
 		type, css_fixed fixed)
 {
 	uint32_t *bits = &style->i.bits[FILL_OPACITY_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~FILL_OPACITY_MASK) | (((uint32_t)type & 0x1) <<
 			FILL_OPACITY_SHIFT);
-	
+
 	style->i.fill_opacity = fixed;
-	
+
 	return CSS_OK;
 }
 #undef FILL_OPACITY_INDEX
@@ -1094,13 +1094,13 @@ static inline css_error set_flex_basis(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[FLEX_BASIS_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~FLEX_BASIS_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << FLEX_BASIS_SHIFT);
-	
+
 	style->i.flex_basis = length;
-	
+
 	return CSS_OK;
 }
 #undef FLEX_BASIS_INDEX
@@ -1115,11 +1115,11 @@ static inline css_error set_flex_direction(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[FLEX_DIRECTION_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~FLEX_DIRECTION_MASK) | (((uint32_t)type & 0x7) <<
 			FLEX_DIRECTION_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef FLEX_DIRECTION_INDEX
@@ -1134,13 +1134,13 @@ static inline css_error set_flex_grow(css_computed_style *style, uint8_t type,
 		css_fixed fixed)
 {
 	uint32_t *bits = &style->i.bits[FLEX_GROW_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~FLEX_GROW_MASK) | (((uint32_t)type & 0x1) <<
 			FLEX_GROW_SHIFT);
-	
+
 	style->i.flex_grow = fixed;
-	
+
 	return CSS_OK;
 }
 #undef FLEX_GROW_INDEX
@@ -1155,13 +1155,13 @@ static inline css_error set_flex_shrink(css_computed_style *style, uint8_t
 		type, css_fixed fixed)
 {
 	uint32_t *bits = &style->i.bits[FLEX_SHRINK_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~FLEX_SHRINK_MASK) | (((uint32_t)type & 0x1) <<
 			FLEX_SHRINK_SHIFT);
-	
+
 	style->i.flex_shrink = fixed;
-	
+
 	return CSS_OK;
 }
 #undef FLEX_SHRINK_INDEX
@@ -1175,11 +1175,11 @@ static inline css_error set_flex_shrink(css_computed_style *style, uint8_t
 static inline css_error set_flex_wrap(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[FLEX_WRAP_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~FLEX_WRAP_MASK) | (((uint32_t)type & 0x3) <<
 			FLEX_WRAP_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef FLEX_WRAP_INDEX
@@ -1193,10 +1193,10 @@ static inline css_error set_flex_wrap(css_computed_style *style, uint8_t type)
 static inline css_error set_float(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[FLOAT_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~FLOAT_MASK) | (((uint32_t)type & 0x3) << FLOAT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef FLOAT_INDEX
@@ -1211,28 +1211,28 @@ static inline css_error set_font_family(css_computed_style *style, uint8_t
 		type, lwc_string **string_arr)
 {
 	uint32_t *bits = &style->i.bits[FONT_FAMILY_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~FONT_FAMILY_MASK) | (((uint32_t)type & 0x7) <<
 			FONT_FAMILY_SHIFT);
-	
+
 	lwc_string **old_string_arr = style->font_family;
 	lwc_string **s;
-	
+
 	for (s = string_arr; s != NULL && *s != NULL; s++)
 		*s = lwc_string_ref(*s);
-	
+
 	style->font_family = string_arr;
-	
+
 	/* Free existing array */
 	if (old_string_arr != NULL) {
 		for (s = old_string_arr; *s != NULL; s++)
 			lwc_string_unref(*s);
-		
+
 		if (old_string_arr != string_arr)
 			free(old_string_arr);
 	}
-	
+
 	return CSS_OK;
 }
 #undef FONT_FAMILY_INDEX
@@ -1247,13 +1247,13 @@ static inline css_error set_font_size(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[FONT_SIZE_INDEX];
-	
+
 	/* 9bits: uuuuutttt : unit | type */
 	*bits = (*bits & ~FONT_SIZE_MASK) | ((((uint32_t)type & 0xf) | (unit <<
 			4)) << FONT_SIZE_SHIFT);
-	
+
 	style->i.font_size = length;
-	
+
 	return CSS_OK;
 }
 #undef FONT_SIZE_INDEX
@@ -1267,11 +1267,11 @@ static inline css_error set_font_size(css_computed_style *style, uint8_t type,
 static inline css_error set_font_style(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[FONT_STYLE_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~FONT_STYLE_MASK) | (((uint32_t)type & 0x3) <<
 			FONT_STYLE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef FONT_STYLE_INDEX
@@ -1286,11 +1286,11 @@ static inline css_error set_font_variant(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[FONT_VARIANT_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~FONT_VARIANT_MASK) | (((uint32_t)type & 0x3) <<
 			FONT_VARIANT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef FONT_VARIANT_INDEX
@@ -1304,11 +1304,11 @@ static inline css_error set_font_variant(css_computed_style *style, uint8_t
 static inline css_error set_font_weight(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[FONT_WEIGHT_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~FONT_WEIGHT_MASK) | (((uint32_t)type & 0xf) <<
 			FONT_WEIGHT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef FONT_WEIGHT_INDEX
@@ -1323,13 +1323,13 @@ static inline css_error set_height(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[HEIGHT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~HEIGHT_MASK) | ((((uint32_t)type & 0x3) | (unit <<
 			2)) << HEIGHT_SHIFT);
-	
+
 	style->i.height = length;
-	
+
 	return CSS_OK;
 }
 #undef HEIGHT_INDEX
@@ -1344,11 +1344,11 @@ static inline css_error set_justify_content(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[JUSTIFY_CONTENT_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~JUSTIFY_CONTENT_MASK) | (((uint32_t)type & 0x7) <<
 			JUSTIFY_CONTENT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef JUSTIFY_CONTENT_INDEX
@@ -1363,13 +1363,13 @@ static inline css_error set_left(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[LEFT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~LEFT_MASK) | ((((uint32_t)type & 0x3) | (unit << 2))
 			<< LEFT_SHIFT);
-	
+
 	style->i.left = length;
-	
+
 	return CSS_OK;
 }
 #undef LEFT_INDEX
@@ -1384,13 +1384,13 @@ static inline css_error set_letter_spacing(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[LETTER_SPACING_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~LETTER_SPACING_MASK) | ((((uint32_t)type & 0x3) | (
 			unit << 2)) << LETTER_SPACING_SHIFT);
-	
+
 	style->i.letter_spacing = length;
-	
+
 	return CSS_OK;
 }
 #undef LETTER_SPACING_INDEX
@@ -1405,13 +1405,13 @@ static inline css_error set_line_height(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[LINE_HEIGHT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~LINE_HEIGHT_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << LINE_HEIGHT_SHIFT);
-	
+
 	style->i.line_height = length;
-	
+
 	return CSS_OK;
 }
 #undef LINE_HEIGHT_INDEX
@@ -1426,21 +1426,21 @@ static inline css_error set_list_style_image(css_computed_style *style, uint8_t
 		type, lwc_string *string)
 {
 	uint32_t *bits = &style->i.bits[LIST_STYLE_IMAGE_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~LIST_STYLE_IMAGE_MASK) | (((uint32_t)type & 0x1) <<
 			LIST_STYLE_IMAGE_SHIFT);
-	
+
 	lwc_string *old_string = style->i.list_style_image;
-	
+
 	if (string != NULL) {
 		style->i.list_style_image = lwc_string_ref(string);
 	} else {
 		style->i.list_style_image = NULL;
 	}
-	
+
 	lwc_string_unref(old_string);
-	
+
 	return CSS_OK;
 }
 #undef LIST_STYLE_IMAGE_INDEX
@@ -1455,11 +1455,11 @@ static inline css_error set_list_style_position(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[LIST_STYLE_POSITION_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~LIST_STYLE_POSITION_MASK) | (((uint32_t)type & 0x3)
 			<< LIST_STYLE_POSITION_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef LIST_STYLE_POSITION_INDEX
@@ -1474,11 +1474,11 @@ static inline css_error set_list_style_type(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[LIST_STYLE_TYPE_INDEX];
-	
+
 	/* 6bits: tttttt : type */
 	*bits = (*bits & ~LIST_STYLE_TYPE_MASK) | (((uint32_t)type & 0x3f) <<
 			LIST_STYLE_TYPE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef LIST_STYLE_TYPE_INDEX
@@ -1493,13 +1493,13 @@ static inline css_error set_margin_bottom(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MARGIN_BOTTOM_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MARGIN_BOTTOM_MASK) | ((((uint32_t)type & 0x3) | (
 			unit << 2)) << MARGIN_BOTTOM_SHIFT);
-	
+
 	style->i.margin_bottom = length;
-	
+
 	return CSS_OK;
 }
 #undef MARGIN_BOTTOM_INDEX
@@ -1514,13 +1514,13 @@ static inline css_error set_margin_left(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MARGIN_LEFT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MARGIN_LEFT_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << MARGIN_LEFT_SHIFT);
-	
+
 	style->i.margin_left = length;
-	
+
 	return CSS_OK;
 }
 #undef MARGIN_LEFT_INDEX
@@ -1535,13 +1535,13 @@ static inline css_error set_margin_right(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MARGIN_RIGHT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MARGIN_RIGHT_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << MARGIN_RIGHT_SHIFT);
-	
+
 	style->i.margin_right = length;
-	
+
 	return CSS_OK;
 }
 #undef MARGIN_RIGHT_INDEX
@@ -1556,13 +1556,13 @@ static inline css_error set_margin_top(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MARGIN_TOP_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MARGIN_TOP_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << MARGIN_TOP_SHIFT);
-	
+
 	style->i.margin_top = length;
-	
+
 	return CSS_OK;
 }
 #undef MARGIN_TOP_INDEX
@@ -1577,13 +1577,13 @@ static inline css_error set_max_height(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MAX_HEIGHT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MAX_HEIGHT_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << MAX_HEIGHT_SHIFT);
-	
+
 	style->i.max_height = length;
-	
+
 	return CSS_OK;
 }
 #undef MAX_HEIGHT_INDEX
@@ -1598,13 +1598,13 @@ static inline css_error set_max_width(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MAX_WIDTH_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MAX_WIDTH_MASK) | ((((uint32_t)type & 0x3) | (unit <<
 			2)) << MAX_WIDTH_SHIFT);
-	
+
 	style->i.max_width = length;
-	
+
 	return CSS_OK;
 }
 #undef MAX_WIDTH_INDEX
@@ -1619,13 +1619,13 @@ static inline css_error set_min_height(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MIN_HEIGHT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MIN_HEIGHT_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << MIN_HEIGHT_SHIFT);
-	
+
 	style->i.min_height = length;
-	
+
 	return CSS_OK;
 }
 #undef MIN_HEIGHT_INDEX
@@ -1640,13 +1640,13 @@ static inline css_error set_min_width(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[MIN_WIDTH_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~MIN_WIDTH_MASK) | ((((uint32_t)type & 0x3) | (unit <<
 			2)) << MIN_WIDTH_SHIFT);
-	
+
 	style->i.min_width = length;
-	
+
 	return CSS_OK;
 }
 #undef MIN_WIDTH_INDEX
@@ -1661,13 +1661,13 @@ static inline css_error set_opacity(css_computed_style *style, uint8_t type,
 		css_fixed fixed)
 {
 	uint32_t *bits = &style->i.bits[OPACITY_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~OPACITY_MASK) | (((uint32_t)type & 0x1) <<
 			OPACITY_SHIFT);
-	
+
 	style->i.opacity = fixed;
-	
+
 	return CSS_OK;
 }
 #undef OPACITY_INDEX
@@ -1682,12 +1682,12 @@ static inline css_error set_order(css_computed_style *style, uint8_t type,
 		int32_t integer)
 {
 	uint32_t *bits = &style->i.bits[ORDER_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~ORDER_MASK) | (((uint32_t)type & 0x1) << ORDER_SHIFT);
-	
+
 	style->i.order = integer;
-	
+
 	return CSS_OK;
 }
 #undef ORDER_INDEX
@@ -1702,13 +1702,13 @@ static inline css_error set_orphans(css_computed_style *style, uint8_t type,
 		int32_t integer)
 {
 	uint32_t *bits = &style->i.bits[ORPHANS_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~ORPHANS_MASK) | (((uint32_t)type & 0x1) <<
 			ORPHANS_SHIFT);
-	
+
 	style->i.orphans = integer;
-	
+
 	return CSS_OK;
 }
 #undef ORPHANS_INDEX
@@ -1723,13 +1723,13 @@ static inline css_error set_outline_color(css_computed_style *style, uint8_t
 		type, css_color color)
 {
 	uint32_t *bits = &style->i.bits[OUTLINE_COLOR_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~OUTLINE_COLOR_MASK) | (((uint32_t)type & 0x3) <<
 			OUTLINE_COLOR_SHIFT);
-	
+
 	style->i.outline_color = color;
-	
+
 	return CSS_OK;
 }
 #undef OUTLINE_COLOR_INDEX
@@ -1744,11 +1744,11 @@ static inline css_error set_outline_style(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[OUTLINE_STYLE_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~OUTLINE_STYLE_MASK) | (((uint32_t)type & 0xf) <<
 			OUTLINE_STYLE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef OUTLINE_STYLE_INDEX
@@ -1763,13 +1763,13 @@ static inline css_error set_outline_width(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[OUTLINE_WIDTH_INDEX];
-	
+
 	/* 8bits: uuuuuttt : unit | type */
 	*bits = (*bits & ~OUTLINE_WIDTH_MASK) | ((((uint32_t)type & 0x7) | (
 			unit << 3)) << OUTLINE_WIDTH_SHIFT);
-	
+
 	style->i.outline_width = length;
-	
+
 	return CSS_OK;
 }
 #undef OUTLINE_WIDTH_INDEX
@@ -1783,11 +1783,11 @@ static inline css_error set_outline_width(css_computed_style *style, uint8_t
 static inline css_error set_overflow_x(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[OVERFLOW_X_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~OVERFLOW_X_MASK) | (((uint32_t)type & 0x7) <<
 			OVERFLOW_X_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef OVERFLOW_X_INDEX
@@ -1801,11 +1801,11 @@ static inline css_error set_overflow_x(css_computed_style *style, uint8_t type)
 static inline css_error set_overflow_y(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[OVERFLOW_Y_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~OVERFLOW_Y_MASK) | (((uint32_t)type & 0x7) <<
 			OVERFLOW_Y_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef OVERFLOW_Y_INDEX
@@ -1820,13 +1820,13 @@ static inline css_error set_padding_bottom(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[PADDING_BOTTOM_INDEX];
-	
+
 	/* 6bits: uuuuut : unit | type */
 	*bits = (*bits & ~PADDING_BOTTOM_MASK) | ((((uint32_t)type & 0x1) | (
 			unit << 1)) << PADDING_BOTTOM_SHIFT);
-	
+
 	style->i.padding_bottom = length;
-	
+
 	return CSS_OK;
 }
 #undef PADDING_BOTTOM_INDEX
@@ -1841,13 +1841,13 @@ static inline css_error set_padding_left(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[PADDING_LEFT_INDEX];
-	
+
 	/* 6bits: uuuuut : unit | type */
 	*bits = (*bits & ~PADDING_LEFT_MASK) | ((((uint32_t)type & 0x1) | (unit
 			<< 1)) << PADDING_LEFT_SHIFT);
-	
+
 	style->i.padding_left = length;
-	
+
 	return CSS_OK;
 }
 #undef PADDING_LEFT_INDEX
@@ -1862,13 +1862,13 @@ static inline css_error set_padding_right(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[PADDING_RIGHT_INDEX];
-	
+
 	/* 6bits: uuuuut : unit | type */
 	*bits = (*bits & ~PADDING_RIGHT_MASK) | ((((uint32_t)type & 0x1) | (
 			unit << 1)) << PADDING_RIGHT_SHIFT);
-	
+
 	style->i.padding_right = length;
-	
+
 	return CSS_OK;
 }
 #undef PADDING_RIGHT_INDEX
@@ -1883,13 +1883,13 @@ static inline css_error set_padding_top(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[PADDING_TOP_INDEX];
-	
+
 	/* 6bits: uuuuut : unit | type */
 	*bits = (*bits & ~PADDING_TOP_MASK) | ((((uint32_t)type & 0x1) | (unit
 			<< 1)) << PADDING_TOP_SHIFT);
-	
+
 	style->i.padding_top = length;
-	
+
 	return CSS_OK;
 }
 #undef PADDING_TOP_INDEX
@@ -1904,11 +1904,11 @@ static inline css_error set_page_break_after(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[PAGE_BREAK_AFTER_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~PAGE_BREAK_AFTER_MASK) | (((uint32_t)type & 0x7) <<
 			PAGE_BREAK_AFTER_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef PAGE_BREAK_AFTER_INDEX
@@ -1923,11 +1923,11 @@ static inline css_error set_page_break_before(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[PAGE_BREAK_BEFORE_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~PAGE_BREAK_BEFORE_MASK) | (((uint32_t)type & 0x7) <<
 			PAGE_BREAK_BEFORE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef PAGE_BREAK_BEFORE_INDEX
@@ -1942,11 +1942,11 @@ static inline css_error set_page_break_inside(css_computed_style *style,
 		uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[PAGE_BREAK_INSIDE_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~PAGE_BREAK_INSIDE_MASK) | (((uint32_t)type & 0x3) <<
 			PAGE_BREAK_INSIDE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef PAGE_BREAK_INSIDE_INDEX
@@ -1960,11 +1960,11 @@ static inline css_error set_page_break_inside(css_computed_style *style,
 static inline css_error set_position(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[POSITION_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~POSITION_MASK) | (((uint32_t)type & 0x7) <<
 			POSITION_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef POSITION_INDEX
@@ -1979,28 +1979,28 @@ static inline css_error set_quotes(css_computed_style *style, uint8_t type,
 		lwc_string **string_arr)
 {
 	uint32_t *bits = &style->i.bits[QUOTES_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~QUOTES_MASK) | (((uint32_t)type & 0x1) <<
 			QUOTES_SHIFT);
-	
+
 	lwc_string **old_string_arr = style->quotes;
 	lwc_string **s;
-	
+
 	for (s = string_arr; s != NULL && *s != NULL; s++)
 		*s = lwc_string_ref(*s);
-	
+
 	style->quotes = string_arr;
-	
+
 	/* Free existing array */
 	if (old_string_arr != NULL) {
 		for (s = old_string_arr; *s != NULL; s++)
 			lwc_string_unref(*s);
-		
+
 		if (old_string_arr != string_arr)
 			free(old_string_arr);
 	}
-	
+
 	return CSS_OK;
 }
 #undef QUOTES_INDEX
@@ -2015,13 +2015,13 @@ static inline css_error set_right(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[RIGHT_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~RIGHT_MASK) | ((((uint32_t)type & 0x3) | (unit << 2))
 			<< RIGHT_SHIFT);
-	
+
 	style->i.right = length;
-	
+
 	return CSS_OK;
 }
 #undef RIGHT_INDEX
@@ -2036,13 +2036,13 @@ static inline css_error set_stroke_opacity(css_computed_style *style, uint8_t
 		type, css_fixed fixed)
 {
 	uint32_t *bits = &style->i.bits[STROKE_OPACITY_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~STROKE_OPACITY_MASK) | (((uint32_t)type & 0x1) <<
 			STROKE_OPACITY_SHIFT);
-	
+
 	style->i.stroke_opacity = fixed;
-	
+
 	return CSS_OK;
 }
 #undef STROKE_OPACITY_INDEX
@@ -2057,11 +2057,11 @@ static inline css_error set_table_layout(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[TABLE_LAYOUT_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~TABLE_LAYOUT_MASK) | (((uint32_t)type & 0x3) <<
 			TABLE_LAYOUT_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef TABLE_LAYOUT_INDEX
@@ -2075,11 +2075,11 @@ static inline css_error set_table_layout(css_computed_style *style, uint8_t
 static inline css_error set_text_align(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[TEXT_ALIGN_INDEX];
-	
+
 	/* 4bits: tttt : type */
 	*bits = (*bits & ~TEXT_ALIGN_MASK) | (((uint32_t)type & 0xf) <<
 			TEXT_ALIGN_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef TEXT_ALIGN_INDEX
@@ -2094,11 +2094,11 @@ static inline css_error set_text_decoration(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[TEXT_DECORATION_INDEX];
-	
+
 	/* 5bits: ttttt : type */
 	*bits = (*bits & ~TEXT_DECORATION_MASK) | (((uint32_t)type & 0x1f) <<
 			TEXT_DECORATION_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef TEXT_DECORATION_INDEX
@@ -2113,13 +2113,13 @@ static inline css_error set_text_indent(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[TEXT_INDENT_INDEX];
-	
+
 	/* 6bits: uuuuut : unit | type */
 	*bits = (*bits & ~TEXT_INDENT_MASK) | ((((uint32_t)type & 0x1) | (unit
 			<< 1)) << TEXT_INDENT_SHIFT);
-	
+
 	style->i.text_indent = length;
-	
+
 	return CSS_OK;
 }
 #undef TEXT_INDENT_INDEX
@@ -2134,11 +2134,11 @@ static inline css_error set_text_transform(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[TEXT_TRANSFORM_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~TEXT_TRANSFORM_MASK) | (((uint32_t)type & 0x7) <<
 			TEXT_TRANSFORM_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef TEXT_TRANSFORM_INDEX
@@ -2153,13 +2153,13 @@ static inline css_error set_top(css_computed_style *style, uint8_t type,
 		css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[TOP_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~TOP_MASK) | ((((uint32_t)type & 0x3) | (unit << 2))
 			<< TOP_SHIFT);
-	
+
 	style->i.top = length;
-	
+
 	return CSS_OK;
 }
 #undef TOP_INDEX
@@ -2174,11 +2174,11 @@ static inline css_error set_unicode_bidi(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[UNICODE_BIDI_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~UNICODE_BIDI_MASK) | (((uint32_t)type & 0x3) <<
 			UNICODE_BIDI_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef UNICODE_BIDI_INDEX
@@ -2193,13 +2193,13 @@ static inline css_error set_vertical_align(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[VERTICAL_ALIGN_INDEX];
-	
+
 	/* 9bits: uuuuutttt : unit | type */
 	*bits = (*bits & ~VERTICAL_ALIGN_MASK) | ((((uint32_t)type & 0xf) | (
 			unit << 4)) << VERTICAL_ALIGN_SHIFT);
-	
+
 	style->i.vertical_align = length;
-	
+
 	return CSS_OK;
 }
 #undef VERTICAL_ALIGN_INDEX
@@ -2213,11 +2213,11 @@ static inline css_error set_vertical_align(css_computed_style *style, uint8_t
 static inline css_error set_visibility(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[VISIBILITY_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~VISIBILITY_MASK) | (((uint32_t)type & 0x3) <<
 			VISIBILITY_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef VISIBILITY_INDEX
@@ -2231,11 +2231,11 @@ static inline css_error set_visibility(css_computed_style *style, uint8_t type)
 static inline css_error set_white_space(css_computed_style *style, uint8_t type)
 {
 	uint32_t *bits = &style->i.bits[WHITE_SPACE_INDEX];
-	
+
 	/* 3bits: ttt : type */
 	*bits = (*bits & ~WHITE_SPACE_MASK) | (((uint32_t)type & 0x7) <<
 			WHITE_SPACE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef WHITE_SPACE_INDEX
@@ -2250,13 +2250,13 @@ static inline css_error set_widows(css_computed_style *style, uint8_t type,
 		int32_t integer)
 {
 	uint32_t *bits = &style->i.bits[WIDOWS_INDEX];
-	
+
 	/* 1bit: t : type */
 	*bits = (*bits & ~WIDOWS_MASK) | (((uint32_t)type & 0x1) <<
 			WIDOWS_SHIFT);
-	
+
 	style->i.widows = integer;
-	
+
 	return CSS_OK;
 }
 #undef WIDOWS_INDEX
@@ -2272,26 +2272,26 @@ static inline css_error set_width(css_computed_style *style, uint8_t type,
 {
 	uint32_t orig_bits = (style->i.bits[WIDTH_INDEX] & WIDTH_MASK) >>
 			WIDTH_SHIFT;
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	if ((orig_bits & 0x3) == CSS_WIDTH_SET) {
 		if ((orig_bits & 0x7c) >> 2 == CSS_UNIT_CALC) {
 			lwc_string_unref(style->i.width.calc);
 		}
 	}
-	
+
 	uint32_t *bits = &style->i.bits[WIDTH_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~WIDTH_MASK) | ((((uint32_t)type & 0x3) | (unit << 2))
 			<< WIDTH_SHIFT);
-	
+
 	if (unit == CSS_UNIT_CALC) {
 		style->i.width.calc = lwc_string_ref(length.calc);
 	} else {
 		style->i.width.value = length.value;
 	}
-	
+
 	return CSS_OK;
 }
 #undef WIDTH_INDEX
@@ -2306,13 +2306,13 @@ static inline css_error set_word_spacing(css_computed_style *style, uint8_t
 		type, css_fixed length, css_unit unit)
 {
 	uint32_t *bits = &style->i.bits[WORD_SPACING_INDEX];
-	
+
 	/* 7bits: uuuuutt : unit | type */
 	*bits = (*bits & ~WORD_SPACING_MASK) | ((((uint32_t)type & 0x3) | (unit
 			<< 2)) << WORD_SPACING_SHIFT);
-	
+
 	style->i.word_spacing = length;
-	
+
 	return CSS_OK;
 }
 #undef WORD_SPACING_INDEX
@@ -2327,11 +2327,11 @@ static inline css_error set_writing_mode(css_computed_style *style, uint8_t
 		type)
 {
 	uint32_t *bits = &style->i.bits[WRITING_MODE_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~WRITING_MODE_MASK) | (((uint32_t)type & 0x3) <<
 			WRITING_MODE_SHIFT);
-	
+
 	return CSS_OK;
 }
 #undef WRITING_MODE_INDEX
@@ -2346,13 +2346,13 @@ static inline css_error set_z_index(css_computed_style *style, uint8_t type,
 		int32_t integer)
 {
 	uint32_t *bits = &style->i.bits[Z_INDEX_INDEX];
-	
+
 	/* 2bits: tt : type */
 	*bits = (*bits & ~Z_INDEX_MASK) | (((uint32_t)type & 0x3) <<
 			Z_INDEX_SHIFT);
-	
+
 	style->i.z_index = integer;
-	
+
 	return CSS_OK;
 }
 #undef Z_INDEX_INDEX

--- a/src/select/select_generator.py
+++ b/src/select/select_generator.py
@@ -76,10 +76,13 @@ class Text:
             pre_formatted: just add text without preprocessing.
         """
         if not text:
-            self._lines.append('{}{}{}'.format(
-                '\t' * self._indent,
-                ' * ' if self._comment else '',
-                '\t' * (9 - self._indent) + '\\' if self._esc_nl else ''))
+            if not self._comment:
+                self._lines.append('')
+            else:
+                self._lines.append('{}{}{}'.format(
+                    '\t' * self._indent,
+                    ' * ' if self._comment else '',
+                    '\t' * (9 - self._indent) + '\\' if self._esc_nl else ''))
             return
 
         if isinstance(text, list):

--- a/src/select/select_generator.py
+++ b/src/select/select_generator.py
@@ -659,6 +659,7 @@ class CSSGroup:
         t.append('{')
         t.indent(1)
 
+        t.append('uint8_t type;')
         t.append('uint32_t bits = style->i.bits[{}_INDEX];'.format(
             p.name.upper()))
         t.append('bits &= {}_MASK;'.format(p.name.upper()))
@@ -667,11 +668,11 @@ class CSSGroup:
 
         type_mask, shift_list, bits_comment = p.get_bits()
         t.append(bits_comment)
+        t.append('type = bits & {};'.format(type_mask))
 
         if only_bits == False:
             if p.condition:
-                t.append('if ((bits & {}) == {}) {{'.format(
-                    type_mask, p.condition))
+                t.append('if (type == {}) {{'.format(p.condition))
                 t.indent(1)
 
             for v in p.values:
@@ -691,7 +692,7 @@ class CSSGroup:
                 t.append('}')
             t.append()
 
-        t.append('return (bits & {});'.format(type_mask))
+        t.append('return type;')
 
         t.indent(-1)
         t.append('}')


### PR DESCRIPTION
This is a couple of tidy-ups.

The first makes the code flow easier for the compiler to reason about.
This prevents bogus "value may be used uninitialised" warnings.

The second removes trailing whitespace on blank lines.