### PR TITLE
select: fix counter-increment/reset dropping named counters

### DIFF
--- a/src/select/properties/helpers.c
+++ b/src/select/properties/helpers.c
@@ -527,6 +527,8 @@ css_error css__cascade_counter_increment_reset(uint32_t opv, css_style *style,
 		{
 			uint32_t v = getValue(opv);
 
+			value = CSS_COUNTER_INCREMENT_NAMED;
+
 			while (v != COUNTER_INCREMENT_NONE) {
 				css_computed_counter *temp;
 				lwc_string *name;

--- a/src/select/strings.c
+++ b/src/select/strings.c
@@ -160,7 +160,7 @@ css_error css_select_strings_intern(css_select_strings *str)
 		return css_error_from_lwc_error(error);
 
 	error = lwc_intern_string(
-			"first_letter", SLEN("first-letter"),
+			"first-letter", SLEN("first-letter"),
 			&str->first_letter);
 	if (error != lwc_error_ok)
 		return css_error_from_lwc_error(error);

--- a/test/data/select/INDEX
+++ b/test/data/select/INDEX
@@ -5,3 +5,4 @@
 tests1.dat		Basic tests
 defaulting.dat		Explicit defaulting tests
 calc.dat		Tests involving calc
+counter.dat		counter-increment/counter-reset named counters

--- a/test/data/select/counter.dat
+++ b/test/data/select/counter.dat
@@ -1,0 +1,232 @@
+#tree
+| div
+|  id=foo
+|  p*
+|   class=green
+#ua
+p { display: block; }
+#user
+#author
+p { counter-increment: mycounter 5; counter-reset: sec 3; }
+#errors
+#expected
+align-content: stretch
+align-items: stretch
+align-self: auto
+background-attachment: scroll
+background-color: #00000000
+background-image: none
+background-position: 0% 0%
+background-repeat: repeat
+border-collapse: separate
+border-spacing: 0px 0px
+border-top-color: #ff000000
+border-right-color: #ff000000
+border-bottom-color: #ff000000
+border-left-color: #ff000000
+border-top-style: none
+border-right-style: none
+border-bottom-style: none
+border-left-style: none
+border-top-width: 2px
+border-right-width: 2px
+border-bottom-width: 2px
+border-left-width: 2px
+bottom: auto
+box-sizing: content-box
+break-after: auto
+break-before: auto
+break-inside: auto
+caption-side: top
+clear: none
+clip: auto
+color: #ff000000
+column-count: auto
+column-fill: balance
+column-gap: normal
+column-rule-color: #ff000000
+column-rule-style: none
+column-rule-width: 2px
+column-span: none
+column-width: auto
+content: normal
+counter-increment: mycounter 5.000
+counter-reset: sec 3.000
+cursor: auto
+direction: ltr
+display: block
+empty-cells: show
+fill-opacity: 1.000
+flex-basis: auto
+flex-direction: row
+flex-grow: 0.000
+flex-shrink: 1.000
+flex-wrap: nowrap
+float: none
+font-family: sans-serif
+font-size: 16px
+font-style: normal
+font-variant: normal
+font-weight: normal
+height: auto
+justify-content: flex-start
+left: auto
+letter-spacing: normal
+line-height: normal
+list-style-image: none
+list-style-position: outside
+list-style-type: disc
+margin-top: 0px
+margin-right: 0px
+margin-bottom: 0px
+margin-left: 0px
+max-height: none
+max-width: none
+min-height: 0px
+min-width: 0px
+opacity: 1.000
+order: 0
+outline-color: invert
+outline-style: none
+outline-width: 2px
+overflow-x: visible
+overflow-y: visible
+padding-top: 0px
+padding-right: 0px
+padding-bottom: 0px
+padding-left: 0px
+position: static
+quotes: none
+right: auto
+stroke-opacity: 1.000
+table-layout: auto
+text-align: default
+text-decoration: none
+text-indent: 0px
+text-transform: none
+top: auto
+unicode-bidi: normal
+vertical-align: baseline
+visibility: visible
+white-space: normal
+width: auto
+word-spacing: normal
+writing-mode: horizontal-tb
+z-index: auto
+#reset
+#tree
+| div
+|  id=foo
+|  p*
+|   class=green
+#ua
+p { display: block; }
+#user
+#author
+p { counter-reset: chapter; }
+#errors
+#expected
+align-content: stretch
+align-items: stretch
+align-self: auto
+background-attachment: scroll
+background-color: #00000000
+background-image: none
+background-position: 0% 0%
+background-repeat: repeat
+border-collapse: separate
+border-spacing: 0px 0px
+border-top-color: #ff000000
+border-right-color: #ff000000
+border-bottom-color: #ff000000
+border-left-color: #ff000000
+border-top-style: none
+border-right-style: none
+border-bottom-style: none
+border-left-style: none
+border-top-width: 2px
+border-right-width: 2px
+border-bottom-width: 2px
+border-left-width: 2px
+bottom: auto
+box-sizing: content-box
+break-after: auto
+break-before: auto
+break-inside: auto
+caption-side: top
+clear: none
+clip: auto
+color: #ff000000
+column-count: auto
+column-fill: balance
+column-gap: normal
+column-rule-color: #ff000000
+column-rule-style: none
+column-rule-width: 2px
+column-span: none
+column-width: auto
+content: normal
+counter-increment: none
+counter-reset: chapter 0.000
+cursor: auto
+direction: ltr
+display: block
+empty-cells: show
+fill-opacity: 1.000
+flex-basis: auto
+flex-direction: row
+flex-grow: 0.000
+flex-shrink: 1.000
+flex-wrap: nowrap
+float: none
+font-family: sans-serif
+font-size: 16px
+font-style: normal
+font-variant: normal
+font-weight: normal
+height: auto
+justify-content: flex-start
+left: auto
+letter-spacing: normal
+line-height: normal
+list-style-image: none
+list-style-position: outside
+list-style-type: disc
+margin-top: 0px
+margin-right: 0px
+margin-bottom: 0px
+margin-left: 0px
+max-height: none
+max-width: none
+min-height: 0px
+min-width: 0px
+opacity: 1.000
+order: 0
+outline-color: invert
+outline-style: none
+outline-width: 2px
+overflow-x: visible
+overflow-y: visible
+padding-top: 0px
+padding-right: 0px
+padding-bottom: 0px
+padding-left: 0px
+position: static
+quotes: none
+right: auto
+stroke-opacity: 1.000
+table-layout: auto
+text-align: default
+text-decoration: none
+text-indent: 0px
+text-transform: none
+top: auto
+unicode-bidi: normal
+vertical-align: baseline
+visibility: visible
+white-space: normal
+width: auto
+word-spacing: normal
+writing-mode: horizontal-tb
+z-index: auto
+#reset


### PR DESCRIPTION
css__cascade_counter_increment_reset() builds the computed counter array in the COUNTER_INCREMENT_NAMED case but never sets `value` to CSS_COUNTER_INCREMENT_NAMED. `value` stays at its initial CSS_COUNTER_INCREMENT_INHERIT (0x0), so the named counters are handed to the property setter tagged as INHERIT and discarded — computed counter-increment/counter-reset always read back as none/inherit.

The helper is shared, so both counter-increment and counter-reset were affected. Set value = CSS_COUNTER_INCREMENT_NAMED once counters are read.