### PR TITLE
select: code generator: Don't generate _bits getter variants

### DIFF
--- a/src/select/autogenerated_propget.h
+++ b/src/select/autogenerated_propget.h
@@ -12,17 +12,6 @@
 #define ALIGN_CONTENT_INDEX 10
 #define ALIGN_CONTENT_SHIFT 20
 #define ALIGN_CONTENT_MASK 0x700000
-static inline uint8_t get_align_content_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[ALIGN_CONTENT_INDEX];
-	bits &= ALIGN_CONTENT_MASK;
-	bits >>= ALIGN_CONTENT_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_align_content(const css_computed_style *style)
 {
 	uint8_t type;
@@ -42,17 +31,6 @@ static inline uint8_t get_align_content(const css_computed_style *style)
 #define ALIGN_ITEMS_INDEX 10
 #define ALIGN_ITEMS_SHIFT 23
 #define ALIGN_ITEMS_MASK 0x3800000
-static inline uint8_t get_align_items_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[ALIGN_ITEMS_INDEX];
-	bits &= ALIGN_ITEMS_MASK;
-	bits >>= ALIGN_ITEMS_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_align_items(const css_computed_style *style)
 {
 	uint8_t type;
@@ -72,17 +50,6 @@ static inline uint8_t get_align_items(const css_computed_style *style)
 #define ALIGN_SELF_INDEX 10
 #define ALIGN_SELF_SHIFT 26
 #define ALIGN_SELF_MASK 0x1c000000
-static inline uint8_t get_align_self_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[ALIGN_SELF_INDEX];
-	bits &= ALIGN_SELF_MASK;
-	bits >>= ALIGN_SELF_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_align_self(const css_computed_style *style)
 {
 	uint8_t type;
@@ -102,18 +69,6 @@ static inline uint8_t get_align_self(const css_computed_style *style)
 #define BACKGROUND_ATTACHMENT_INDEX 14
 #define BACKGROUND_ATTACHMENT_SHIFT 28
 #define BACKGROUND_ATTACHMENT_MASK 0x30000000
-static inline uint8_t get_background_attachment_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BACKGROUND_ATTACHMENT_INDEX];
-	bits &= BACKGROUND_ATTACHMENT_MASK;
-	bits >>= BACKGROUND_ATTACHMENT_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_background_attachment(const css_computed_style *style)
 {
 	uint8_t type;
@@ -133,17 +88,6 @@ static inline uint8_t get_background_attachment(const css_computed_style *style)
 #define BACKGROUND_COLOR_INDEX 14
 #define BACKGROUND_COLOR_SHIFT 30
 #define BACKGROUND_COLOR_MASK 0xc0000000
-static inline uint8_t get_background_color_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BACKGROUND_COLOR_INDEX];
-	bits &= BACKGROUND_COLOR_MASK;
-	bits >>= BACKGROUND_COLOR_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_background_color(const css_computed_style *style,
 		css_color *color)
 {
@@ -165,17 +109,6 @@ static inline uint8_t get_background_color(const css_computed_style *style,
 #define BACKGROUND_IMAGE_INDEX 14
 #define BACKGROUND_IMAGE_SHIFT 16
 #define BACKGROUND_IMAGE_MASK 0x10000
-static inline uint8_t get_background_image_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BACKGROUND_IMAGE_INDEX];
-	bits &= BACKGROUND_IMAGE_MASK;
-	bits >>= BACKGROUND_IMAGE_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_background_image(const css_computed_style *style,
 		lwc_string **string)
 {
@@ -197,18 +130,6 @@ static inline uint8_t get_background_image(const css_computed_style *style,
 #define BACKGROUND_POSITION_INDEX 12
 #define BACKGROUND_POSITION_SHIFT 10
 #define BACKGROUND_POSITION_MASK 0x1ffc00
-static inline uint8_t get_background_position_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BACKGROUND_POSITION_INDEX];
-	bits &= BACKGROUND_POSITION_MASK;
-	bits >>= BACKGROUND_POSITION_SHIFT;
-
-	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_background_position(const css_computed_style *style,
 		css_fixed *length_a, css_unit *unit_a, css_fixed *length_b,
 		css_unit *unit_b)
@@ -236,18 +157,6 @@ static inline uint8_t get_background_position(const css_computed_style *style,
 #define BACKGROUND_REPEAT_INDEX 10
 #define BACKGROUND_REPEAT_SHIFT 29
 #define BACKGROUND_REPEAT_MASK 0xe0000000
-static inline uint8_t get_background_repeat_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BACKGROUND_REPEAT_INDEX];
-	bits &= BACKGROUND_REPEAT_MASK;
-	bits >>= BACKGROUND_REPEAT_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_background_repeat(const css_computed_style *style)
 {
 	uint8_t type;
@@ -267,18 +176,6 @@ static inline uint8_t get_background_repeat(const css_computed_style *style)
 #define BORDER_BOTTOM_COLOR_INDEX 11
 #define BORDER_BOTTOM_COLOR_SHIFT 0
 #define BORDER_BOTTOM_COLOR_MASK 0x3
-static inline uint8_t get_border_bottom_color_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_BOTTOM_COLOR_INDEX];
-	bits &= BORDER_BOTTOM_COLOR_MASK;
-	bits >>= BORDER_BOTTOM_COLOR_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_border_bottom_color(const css_computed_style *style,
 		css_color *color)
 {
@@ -300,18 +197,6 @@ static inline uint8_t get_border_bottom_color(const css_computed_style *style,
 #define BORDER_BOTTOM_STYLE_INDEX 13
 #define BORDER_BOTTOM_STYLE_SHIFT 28
 #define BORDER_BOTTOM_STYLE_MASK 0xf0000000
-static inline uint8_t get_border_bottom_style_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_BOTTOM_STYLE_INDEX];
-	bits &= BORDER_BOTTOM_STYLE_MASK;
-	bits >>= BORDER_BOTTOM_STYLE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_border_bottom_style(const css_computed_style *style)
 {
 	uint8_t type;
@@ -331,18 +216,6 @@ static inline uint8_t get_border_bottom_style(const css_computed_style *style)
 #define BORDER_BOTTOM_WIDTH_INDEX 0
 #define BORDER_BOTTOM_WIDTH_SHIFT 0
 #define BORDER_BOTTOM_WIDTH_MASK 0xff
-static inline uint8_t get_border_bottom_width_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_BOTTOM_WIDTH_INDEX];
-	bits &= BORDER_BOTTOM_WIDTH_MASK;
-	bits >>= BORDER_BOTTOM_WIDTH_SHIFT;
-
-	/* 8bits: uuuuuttt : unit | type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_border_bottom_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -367,17 +240,6 @@ static inline uint8_t get_border_bottom_width(const css_computed_style *style,
 #define BORDER_COLLAPSE_INDEX 11
 #define BORDER_COLLAPSE_SHIFT 2
 #define BORDER_COLLAPSE_MASK 0xc
-static inline uint8_t get_border_collapse_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_COLLAPSE_INDEX];
-	bits &= BORDER_COLLAPSE_MASK;
-	bits >>= BORDER_COLLAPSE_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_border_collapse(const css_computed_style *style)
 {
 	uint8_t type;
@@ -397,18 +259,6 @@ static inline uint8_t get_border_collapse(const css_computed_style *style)
 #define BORDER_LEFT_COLOR_INDEX 11
 #define BORDER_LEFT_COLOR_SHIFT 4
 #define BORDER_LEFT_COLOR_MASK 0x30
-static inline uint8_t get_border_left_color_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_LEFT_COLOR_INDEX];
-	bits &= BORDER_LEFT_COLOR_MASK;
-	bits >>= BORDER_LEFT_COLOR_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_border_left_color(const css_computed_style *style,
 		css_color *color)
 {
@@ -430,18 +280,6 @@ static inline uint8_t get_border_left_color(const css_computed_style *style,
 #define BORDER_LEFT_STYLE_INDEX 9
 #define BORDER_LEFT_STYLE_SHIFT 3
 #define BORDER_LEFT_STYLE_MASK 0x78
-static inline uint8_t get_border_left_style_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_LEFT_STYLE_INDEX];
-	bits &= BORDER_LEFT_STYLE_MASK;
-	bits >>= BORDER_LEFT_STYLE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_border_left_style(const css_computed_style *style)
 {
 	uint8_t type;
@@ -461,18 +299,6 @@ static inline uint8_t get_border_left_style(const css_computed_style *style)
 #define BORDER_LEFT_WIDTH_INDEX 0
 #define BORDER_LEFT_WIDTH_SHIFT 8
 #define BORDER_LEFT_WIDTH_MASK 0xff00
-static inline uint8_t get_border_left_width_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_LEFT_WIDTH_INDEX];
-	bits &= BORDER_LEFT_WIDTH_MASK;
-	bits >>= BORDER_LEFT_WIDTH_SHIFT;
-
-	/* 8bits: uuuuuttt : unit | type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_border_left_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -497,18 +323,6 @@ static inline uint8_t get_border_left_width(const css_computed_style *style,
 #define BORDER_RIGHT_COLOR_INDEX 11
 #define BORDER_RIGHT_COLOR_SHIFT 6
 #define BORDER_RIGHT_COLOR_MASK 0xc0
-static inline uint8_t get_border_right_color_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_RIGHT_COLOR_INDEX];
-	bits &= BORDER_RIGHT_COLOR_MASK;
-	bits >>= BORDER_RIGHT_COLOR_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_border_right_color(const css_computed_style *style,
 		css_color *color)
 {
@@ -530,18 +344,6 @@ static inline uint8_t get_border_right_color(const css_computed_style *style,
 #define BORDER_RIGHT_STYLE_INDEX 9
 #define BORDER_RIGHT_STYLE_SHIFT 7
 #define BORDER_RIGHT_STYLE_MASK 0x780
-static inline uint8_t get_border_right_style_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_RIGHT_STYLE_INDEX];
-	bits &= BORDER_RIGHT_STYLE_MASK;
-	bits >>= BORDER_RIGHT_STYLE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_border_right_style(const css_computed_style *style)
 {
 	uint8_t type;
@@ -561,18 +363,6 @@ static inline uint8_t get_border_right_style(const css_computed_style *style)
 #define BORDER_RIGHT_WIDTH_INDEX 0
 #define BORDER_RIGHT_WIDTH_SHIFT 16
 #define BORDER_RIGHT_WIDTH_MASK 0xff0000
-static inline uint8_t get_border_right_width_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_RIGHT_WIDTH_INDEX];
-	bits &= BORDER_RIGHT_WIDTH_MASK;
-	bits >>= BORDER_RIGHT_WIDTH_SHIFT;
-
-	/* 8bits: uuuuuttt : unit | type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_border_right_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -597,17 +387,6 @@ static inline uint8_t get_border_right_width(const css_computed_style *style,
 #define BORDER_SPACING_INDEX 12
 #define BORDER_SPACING_SHIFT 21
 #define BORDER_SPACING_MASK 0xffe00000
-static inline uint8_t get_border_spacing_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_SPACING_INDEX];
-	bits &= BORDER_SPACING_MASK;
-	bits >>= BORDER_SPACING_SHIFT;
-
-	/* 11bits: aaaaabbbbbt : unit_a | unit_b | type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_border_spacing(const css_computed_style *style,
 		css_fixed *length_a, css_unit *unit_a, css_fixed *length_b,
 		css_unit *unit_b)
@@ -635,17 +414,6 @@ static inline uint8_t get_border_spacing(const css_computed_style *style,
 #define BORDER_TOP_COLOR_INDEX 11
 #define BORDER_TOP_COLOR_SHIFT 8
 #define BORDER_TOP_COLOR_MASK 0x300
-static inline uint8_t get_border_top_color_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_TOP_COLOR_INDEX];
-	bits &= BORDER_TOP_COLOR_MASK;
-	bits >>= BORDER_TOP_COLOR_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_border_top_color(const css_computed_style *style,
 		css_color *color)
 {
@@ -667,17 +435,6 @@ static inline uint8_t get_border_top_color(const css_computed_style *style,
 #define BORDER_TOP_STYLE_INDEX 9
 #define BORDER_TOP_STYLE_SHIFT 11
 #define BORDER_TOP_STYLE_MASK 0x7800
-static inline uint8_t get_border_top_style_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_TOP_STYLE_INDEX];
-	bits &= BORDER_TOP_STYLE_MASK;
-	bits >>= BORDER_TOP_STYLE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_border_top_style(const css_computed_style *style)
 {
 	uint8_t type;
@@ -697,17 +454,6 @@ static inline uint8_t get_border_top_style(const css_computed_style *style)
 #define BORDER_TOP_WIDTH_INDEX 0
 #define BORDER_TOP_WIDTH_SHIFT 24
 #define BORDER_TOP_WIDTH_MASK 0xff000000
-static inline uint8_t get_border_top_width_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BORDER_TOP_WIDTH_INDEX];
-	bits &= BORDER_TOP_WIDTH_MASK;
-	bits >>= BORDER_TOP_WIDTH_SHIFT;
-
-	/* 8bits: uuuuuttt : unit | type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_border_top_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -732,17 +478,6 @@ static inline uint8_t get_border_top_width(const css_computed_style *style,
 #define BOTTOM_INDEX 3
 #define BOTTOM_SHIFT 11
 #define BOTTOM_MASK 0x3f800
-static inline uint8_t get_bottom_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BOTTOM_INDEX];
-	bits &= BOTTOM_MASK;
-	bits >>= BOTTOM_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_bottom(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -767,17 +502,6 @@ static inline uint8_t get_bottom(const css_computed_style *style, css_fixed
 #define BOX_SIZING_INDEX 11
 #define BOX_SIZING_SHIFT 10
 #define BOX_SIZING_MASK 0xc00
-static inline uint8_t get_box_sizing_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BOX_SIZING_INDEX];
-	bits &= BOX_SIZING_MASK;
-	bits >>= BOX_SIZING_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_box_sizing(const css_computed_style *style)
 {
 	uint8_t type;
@@ -797,17 +521,6 @@ static inline uint8_t get_box_sizing(const css_computed_style *style)
 #define BREAK_AFTER_INDEX 9
 #define BREAK_AFTER_SHIFT 15
 #define BREAK_AFTER_MASK 0x78000
-static inline uint8_t get_break_after_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BREAK_AFTER_INDEX];
-	bits &= BREAK_AFTER_MASK;
-	bits >>= BREAK_AFTER_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_break_after(const css_computed_style *style)
 {
 	uint8_t type;
@@ -827,17 +540,6 @@ static inline uint8_t get_break_after(const css_computed_style *style)
 #define BREAK_BEFORE_INDEX 9
 #define BREAK_BEFORE_SHIFT 19
 #define BREAK_BEFORE_MASK 0x780000
-static inline uint8_t get_break_before_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BREAK_BEFORE_INDEX];
-	bits &= BREAK_BEFORE_MASK;
-	bits >>= BREAK_BEFORE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_break_before(const css_computed_style *style)
 {
 	uint8_t type;
@@ -857,17 +559,6 @@ static inline uint8_t get_break_before(const css_computed_style *style)
 #define BREAK_INSIDE_INDEX 9
 #define BREAK_INSIDE_SHIFT 23
 #define BREAK_INSIDE_MASK 0x7800000
-static inline uint8_t get_break_inside_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[BREAK_INSIDE_INDEX];
-	bits &= BREAK_INSIDE_MASK;
-	bits >>= BREAK_INSIDE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_break_inside(const css_computed_style *style)
 {
 	uint8_t type;
@@ -887,17 +578,6 @@ static inline uint8_t get_break_inside(const css_computed_style *style)
 #define CAPTION_SIDE_INDEX 11
 #define CAPTION_SIDE_SHIFT 12
 #define CAPTION_SIDE_MASK 0x3000
-static inline uint8_t get_caption_side_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[CAPTION_SIDE_INDEX];
-	bits &= CAPTION_SIDE_MASK;
-	bits >>= CAPTION_SIDE_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_caption_side(const css_computed_style *style)
 {
 	uint8_t type;
@@ -917,17 +597,6 @@ static inline uint8_t get_caption_side(const css_computed_style *style)
 #define CLEAR_INDEX 13
 #define CLEAR_SHIFT 1
 #define CLEAR_MASK 0xe
-static inline uint8_t get_clear_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[CLEAR_INDEX];
-	bits &= CLEAR_MASK;
-	bits >>= CLEAR_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_clear(const css_computed_style *style)
 {
 	uint8_t type;
@@ -947,18 +616,6 @@ static inline uint8_t get_clear(const css_computed_style *style)
 #define CLIP_INDEX 2
 #define CLIP_SHIFT 6
 #define CLIP_MASK 0xffffffc0
-static inline uint8_t get_clip_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[CLIP_INDEX];
-	bits &= CLIP_MASK;
-	bits >>= CLIP_SHIFT;
-
-	/* 26bits: aaaaabbbbbcccccdddddtttttt : unit_a | unit_b | unit_c |
-			unit_d | type */
-	type = bits & 0x3f;
-	return type;
-}
 static inline uint8_t get_clip(
 		const css_computed_style *style,
 		css_computed_clip_rect *rect)
@@ -1001,17 +658,6 @@ static inline uint8_t get_clip(
 #define COLOR_INDEX 14
 #define COLOR_SHIFT 17
 #define COLOR_MASK 0x20000
-static inline uint8_t get_color_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLOR_INDEX];
-	bits &= COLOR_MASK;
-	bits >>= COLOR_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_color(const css_computed_style *style, css_color
 		*color)
 {
@@ -1033,17 +679,6 @@ static inline uint8_t get_color(const css_computed_style *style, css_color
 #define COLUMN_COUNT_INDEX 11
 #define COLUMN_COUNT_SHIFT 14
 #define COLUMN_COUNT_MASK 0xc000
-static inline uint8_t get_column_count_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_COUNT_INDEX];
-	bits &= COLUMN_COUNT_MASK;
-	bits >>= COLUMN_COUNT_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_column_count(const css_computed_style *style, int32_t
 		*integer)
 {
@@ -1065,17 +700,6 @@ static inline uint8_t get_column_count(const css_computed_style *style, int32_t
 #define COLUMN_FILL_INDEX 11
 #define COLUMN_FILL_SHIFT 16
 #define COLUMN_FILL_MASK 0x30000
-static inline uint8_t get_column_fill_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_FILL_INDEX];
-	bits &= COLUMN_FILL_MASK;
-	bits >>= COLUMN_FILL_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_column_fill(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1095,17 +719,6 @@ static inline uint8_t get_column_fill(const css_computed_style *style)
 #define COLUMN_GAP_INDEX 3
 #define COLUMN_GAP_SHIFT 18
 #define COLUMN_GAP_MASK 0x1fc0000
-static inline uint8_t get_column_gap_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_GAP_INDEX];
-	bits &= COLUMN_GAP_MASK;
-	bits >>= COLUMN_GAP_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_column_gap(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -1130,18 +743,6 @@ static inline uint8_t get_column_gap(const css_computed_style *style, css_fixed
 #define COLUMN_RULE_COLOR_INDEX 11
 #define COLUMN_RULE_COLOR_SHIFT 18
 #define COLUMN_RULE_COLOR_MASK 0xc0000
-static inline uint8_t get_column_rule_color_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_RULE_COLOR_INDEX];
-	bits &= COLUMN_RULE_COLOR_MASK;
-	bits >>= COLUMN_RULE_COLOR_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_column_rule_color(const css_computed_style *style,
 		css_color *color)
 {
@@ -1163,18 +764,6 @@ static inline uint8_t get_column_rule_color(const css_computed_style *style,
 #define COLUMN_RULE_STYLE_INDEX 7
 #define COLUMN_RULE_STYLE_SHIFT 0
 #define COLUMN_RULE_STYLE_MASK 0xf
-static inline uint8_t get_column_rule_style_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_RULE_STYLE_INDEX];
-	bits &= COLUMN_RULE_STYLE_MASK;
-	bits >>= COLUMN_RULE_STYLE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_column_rule_style(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1194,18 +783,6 @@ static inline uint8_t get_column_rule_style(const css_computed_style *style)
 #define COLUMN_RULE_WIDTH_INDEX 1
 #define COLUMN_RULE_WIDTH_SHIFT 7
 #define COLUMN_RULE_WIDTH_MASK 0x7f80
-static inline uint8_t get_column_rule_width_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_RULE_WIDTH_INDEX];
-	bits &= COLUMN_RULE_WIDTH_MASK;
-	bits >>= COLUMN_RULE_WIDTH_SHIFT;
-
-	/* 8bits: uuuuuttt : unit | type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_column_rule_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -1230,17 +807,6 @@ static inline uint8_t get_column_rule_width(const css_computed_style *style,
 #define COLUMN_SPAN_INDEX 11
 #define COLUMN_SPAN_SHIFT 20
 #define COLUMN_SPAN_MASK 0x300000
-static inline uint8_t get_column_span_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_SPAN_INDEX];
-	bits &= COLUMN_SPAN_MASK;
-	bits >>= COLUMN_SPAN_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_column_span(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1260,17 +826,6 @@ static inline uint8_t get_column_span(const css_computed_style *style)
 #define COLUMN_WIDTH_INDEX 3
 #define COLUMN_WIDTH_SHIFT 25
 #define COLUMN_WIDTH_MASK 0xfe000000
-static inline uint8_t get_column_width_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COLUMN_WIDTH_INDEX];
-	bits &= COLUMN_WIDTH_MASK;
-	bits >>= COLUMN_WIDTH_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_column_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -1295,17 +850,6 @@ static inline uint8_t get_column_width(const css_computed_style *style,
 #define CONTENT_INDEX 11
 #define CONTENT_SHIFT 22
 #define CONTENT_MASK 0xc00000
-static inline uint8_t get_content_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[CONTENT_INDEX];
-	bits &= CONTENT_MASK;
-	bits >>= CONTENT_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_content(const css_computed_style *style, const
 		css_computed_content_item **content_item)
 {
@@ -1329,18 +873,6 @@ static inline uint8_t get_content(const css_computed_style *style, const
 #define COUNTER_INCREMENT_INDEX 14
 #define COUNTER_INCREMENT_SHIFT 18
 #define COUNTER_INCREMENT_MASK 0x40000
-static inline uint8_t get_counter_increment_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COUNTER_INCREMENT_INDEX];
-	bits &= COUNTER_INCREMENT_MASK;
-	bits >>= COUNTER_INCREMENT_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_counter_increment(const css_computed_style *style,
 		const css_computed_counter **counter_arr)
 {
@@ -1362,17 +894,6 @@ static inline uint8_t get_counter_increment(const css_computed_style *style,
 #define COUNTER_RESET_INDEX 14
 #define COUNTER_RESET_SHIFT 19
 #define COUNTER_RESET_MASK 0x80000
-static inline uint8_t get_counter_reset_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[COUNTER_RESET_INDEX];
-	bits &= COUNTER_RESET_MASK;
-	bits >>= COUNTER_RESET_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_counter_reset(const css_computed_style *style, const
 		css_computed_counter **counter_arr)
 {
@@ -1394,17 +915,6 @@ static inline uint8_t get_counter_reset(const css_computed_style *style, const
 #define CURSOR_INDEX 9
 #define CURSOR_SHIFT 27
 #define CURSOR_MASK 0xf8000000
-static inline uint8_t get_cursor_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[CURSOR_INDEX];
-	bits &= CURSOR_MASK;
-	bits >>= CURSOR_SHIFT;
-
-	/* 5bits: ttttt : type */
-	type = bits & 0x1f;
-	return type;
-}
 static inline uint8_t get_cursor(const css_computed_style *style, lwc_string
 		***string_arr)
 {
@@ -1426,17 +936,6 @@ static inline uint8_t get_cursor(const css_computed_style *style, lwc_string
 #define DIRECTION_INDEX 11
 #define DIRECTION_SHIFT 24
 #define DIRECTION_MASK 0x3000000
-static inline uint8_t get_direction_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[DIRECTION_INDEX];
-	bits &= DIRECTION_MASK;
-	bits >>= DIRECTION_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_direction(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1456,17 +955,6 @@ static inline uint8_t get_direction(const css_computed_style *style)
 #define DISPLAY_INDEX 8
 #define DISPLAY_SHIFT 3
 #define DISPLAY_MASK 0xf8
-static inline uint8_t get_display_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[DISPLAY_INDEX];
-	bits &= DISPLAY_MASK;
-	bits >>= DISPLAY_SHIFT;
-
-	/* 5bits: ttttt : type */
-	type = bits & 0x1f;
-	return type;
-}
 static inline uint8_t get_display(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1486,17 +974,6 @@ static inline uint8_t get_display(const css_computed_style *style)
 #define EMPTY_CELLS_INDEX 11
 #define EMPTY_CELLS_SHIFT 26
 #define EMPTY_CELLS_MASK 0xc000000
-static inline uint8_t get_empty_cells_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[EMPTY_CELLS_INDEX];
-	bits &= EMPTY_CELLS_MASK;
-	bits >>= EMPTY_CELLS_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_empty_cells(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1516,17 +993,6 @@ static inline uint8_t get_empty_cells(const css_computed_style *style)
 #define FILL_OPACITY_INDEX 14
 #define FILL_OPACITY_SHIFT 20
 #define FILL_OPACITY_MASK 0x100000
-static inline uint8_t get_fill_opacity_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FILL_OPACITY_INDEX];
-	bits &= FILL_OPACITY_MASK;
-	bits >>= FILL_OPACITY_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_fill_opacity(const css_computed_style *style,
 		css_fixed *fixed)
 {
@@ -1550,17 +1016,6 @@ static inline uint8_t get_fill_opacity(const css_computed_style *style,
 #define FLEX_BASIS_INDEX 7
 #define FLEX_BASIS_SHIFT 4
 #define FLEX_BASIS_MASK 0x7f0
-static inline uint8_t get_flex_basis_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FLEX_BASIS_INDEX];
-	bits &= FLEX_BASIS_MASK;
-	bits >>= FLEX_BASIS_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_flex_basis(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -1585,17 +1040,6 @@ static inline uint8_t get_flex_basis(const css_computed_style *style, css_fixed
 #define FLEX_DIRECTION_INDEX 13
 #define FLEX_DIRECTION_SHIFT 4
 #define FLEX_DIRECTION_MASK 0x70
-static inline uint8_t get_flex_direction_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FLEX_DIRECTION_INDEX];
-	bits &= FLEX_DIRECTION_MASK;
-	bits >>= FLEX_DIRECTION_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_flex_direction(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1615,17 +1059,6 @@ static inline uint8_t get_flex_direction(const css_computed_style *style)
 #define FLEX_GROW_INDEX 14
 #define FLEX_GROW_SHIFT 21
 #define FLEX_GROW_MASK 0x200000
-static inline uint8_t get_flex_grow_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FLEX_GROW_INDEX];
-	bits &= FLEX_GROW_MASK;
-	bits >>= FLEX_GROW_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_flex_grow(const css_computed_style *style, css_fixed
 		*fixed)
 {
@@ -1649,17 +1082,6 @@ static inline uint8_t get_flex_grow(const css_computed_style *style, css_fixed
 #define FLEX_SHRINK_INDEX 14
 #define FLEX_SHRINK_SHIFT 22
 #define FLEX_SHRINK_MASK 0x400000
-static inline uint8_t get_flex_shrink_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FLEX_SHRINK_INDEX];
-	bits &= FLEX_SHRINK_MASK;
-	bits >>= FLEX_SHRINK_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_flex_shrink(const css_computed_style *style,
 		css_fixed *fixed)
 {
@@ -1683,17 +1105,6 @@ static inline uint8_t get_flex_shrink(const css_computed_style *style,
 #define FLEX_WRAP_INDEX 11
 #define FLEX_WRAP_SHIFT 28
 #define FLEX_WRAP_MASK 0x30000000
-static inline uint8_t get_flex_wrap_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FLEX_WRAP_INDEX];
-	bits &= FLEX_WRAP_MASK;
-	bits >>= FLEX_WRAP_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_flex_wrap(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1713,17 +1124,6 @@ static inline uint8_t get_flex_wrap(const css_computed_style *style)
 #define FLOAT_INDEX 11
 #define FLOAT_SHIFT 30
 #define FLOAT_MASK 0xc0000000
-static inline uint8_t get_float_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FLOAT_INDEX];
-	bits &= FLOAT_MASK;
-	bits >>= FLOAT_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_float(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1743,17 +1143,6 @@ static inline uint8_t get_float(const css_computed_style *style)
 #define FONT_FAMILY_INDEX 13
 #define FONT_FAMILY_SHIFT 7
 #define FONT_FAMILY_MASK 0x380
-static inline uint8_t get_font_family_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FONT_FAMILY_INDEX];
-	bits &= FONT_FAMILY_MASK;
-	bits >>= FONT_FAMILY_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_font_family(const css_computed_style *style,
 		lwc_string ***string_arr)
 {
@@ -1775,17 +1164,6 @@ static inline uint8_t get_font_family(const css_computed_style *style,
 #define FONT_SIZE_INDEX 1
 #define FONT_SIZE_SHIFT 23
 #define FONT_SIZE_MASK 0xff800000
-static inline uint8_t get_font_size_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FONT_SIZE_INDEX];
-	bits &= FONT_SIZE_MASK;
-	bits >>= FONT_SIZE_SHIFT;
-
-	/* 9bits: uuuuutttt : unit | type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_font_size(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -1810,17 +1188,6 @@ static inline uint8_t get_font_size(const css_computed_style *style, css_fixed
 #define FONT_STYLE_INDEX 10
 #define FONT_STYLE_SHIFT 0
 #define FONT_STYLE_MASK 0x3
-static inline uint8_t get_font_style_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FONT_STYLE_INDEX];
-	bits &= FONT_STYLE_MASK;
-	bits >>= FONT_STYLE_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_font_style(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1840,17 +1207,6 @@ static inline uint8_t get_font_style(const css_computed_style *style)
 #define FONT_VARIANT_INDEX 10
 #define FONT_VARIANT_SHIFT 2
 #define FONT_VARIANT_MASK 0xc
-static inline uint8_t get_font_variant_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FONT_VARIANT_INDEX];
-	bits &= FONT_VARIANT_MASK;
-	bits >>= FONT_VARIANT_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_font_variant(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1870,17 +1226,6 @@ static inline uint8_t get_font_variant(const css_computed_style *style)
 #define FONT_WEIGHT_INDEX 6
 #define FONT_WEIGHT_SHIFT 0
 #define FONT_WEIGHT_MASK 0xf
-static inline uint8_t get_font_weight_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[FONT_WEIGHT_INDEX];
-	bits &= FONT_WEIGHT_MASK;
-	bits >>= FONT_WEIGHT_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_font_weight(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1900,17 +1245,6 @@ static inline uint8_t get_font_weight(const css_computed_style *style)
 #define HEIGHT_INDEX 7
 #define HEIGHT_SHIFT 11
 #define HEIGHT_MASK 0x3f800
-static inline uint8_t get_height_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[HEIGHT_INDEX];
-	bits &= HEIGHT_MASK;
-	bits >>= HEIGHT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_height(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -1935,17 +1269,6 @@ static inline uint8_t get_height(const css_computed_style *style, css_fixed
 #define JUSTIFY_CONTENT_INDEX 13
 #define JUSTIFY_CONTENT_SHIFT 10
 #define JUSTIFY_CONTENT_MASK 0x1c00
-static inline uint8_t get_justify_content_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[JUSTIFY_CONTENT_INDEX];
-	bits &= JUSTIFY_CONTENT_MASK;
-	bits >>= JUSTIFY_CONTENT_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_justify_content(const css_computed_style *style)
 {
 	uint8_t type;
@@ -1965,17 +1288,6 @@ static inline uint8_t get_justify_content(const css_computed_style *style)
 #define LEFT_INDEX 7
 #define LEFT_SHIFT 18
 #define LEFT_MASK 0x1fc0000
-static inline uint8_t get_left_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[LEFT_INDEX];
-	bits &= LEFT_MASK;
-	bits >>= LEFT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_left(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -2000,17 +1312,6 @@ static inline uint8_t get_left(const css_computed_style *style, css_fixed
 #define LETTER_SPACING_INDEX 7
 #define LETTER_SPACING_SHIFT 25
 #define LETTER_SPACING_MASK 0xfe000000
-static inline uint8_t get_letter_spacing_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[LETTER_SPACING_INDEX];
-	bits &= LETTER_SPACING_MASK;
-	bits >>= LETTER_SPACING_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_letter_spacing(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2035,17 +1336,6 @@ static inline uint8_t get_letter_spacing(const css_computed_style *style,
 #define LINE_HEIGHT_INDEX 6
 #define LINE_HEIGHT_SHIFT 4
 #define LINE_HEIGHT_MASK 0x7f0
-static inline uint8_t get_line_height_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[LINE_HEIGHT_INDEX];
-	bits &= LINE_HEIGHT_MASK;
-	bits >>= LINE_HEIGHT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_line_height(
 		const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
@@ -2073,17 +1363,6 @@ static inline uint8_t get_line_height(
 #define LIST_STYLE_IMAGE_INDEX 14
 #define LIST_STYLE_IMAGE_SHIFT 23
 #define LIST_STYLE_IMAGE_MASK 0x800000
-static inline uint8_t get_list_style_image_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[LIST_STYLE_IMAGE_INDEX];
-	bits &= LIST_STYLE_IMAGE_MASK;
-	bits >>= LIST_STYLE_IMAGE_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_list_style_image(const css_computed_style *style,
 		lwc_string **string)
 {
@@ -2105,18 +1384,6 @@ static inline uint8_t get_list_style_image(const css_computed_style *style,
 #define LIST_STYLE_POSITION_INDEX 10
 #define LIST_STYLE_POSITION_SHIFT 4
 #define LIST_STYLE_POSITION_MASK 0x30
-static inline uint8_t get_list_style_position_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[LIST_STYLE_POSITION_INDEX];
-	bits &= LIST_STYLE_POSITION_MASK;
-	bits >>= LIST_STYLE_POSITION_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_list_style_position(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2136,17 +1403,6 @@ static inline uint8_t get_list_style_position(const css_computed_style *style)
 #define LIST_STYLE_TYPE_INDEX 8
 #define LIST_STYLE_TYPE_SHIFT 8
 #define LIST_STYLE_TYPE_MASK 0x3f00
-static inline uint8_t get_list_style_type_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[LIST_STYLE_TYPE_INDEX];
-	bits &= LIST_STYLE_TYPE_MASK;
-	bits >>= LIST_STYLE_TYPE_SHIFT;
-
-	/* 6bits: tttttt : type */
-	type = bits & 0x3f;
-	return type;
-}
 static inline uint8_t get_list_style_type(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2166,17 +1422,6 @@ static inline uint8_t get_list_style_type(const css_computed_style *style)
 #define MARGIN_BOTTOM_INDEX 6
 #define MARGIN_BOTTOM_SHIFT 11
 #define MARGIN_BOTTOM_MASK 0x3f800
-static inline uint8_t get_margin_bottom_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MARGIN_BOTTOM_INDEX];
-	bits &= MARGIN_BOTTOM_MASK;
-	bits >>= MARGIN_BOTTOM_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_margin_bottom(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2201,17 +1446,6 @@ static inline uint8_t get_margin_bottom(const css_computed_style *style,
 #define MARGIN_LEFT_INDEX 6
 #define MARGIN_LEFT_SHIFT 18
 #define MARGIN_LEFT_MASK 0x1fc0000
-static inline uint8_t get_margin_left_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MARGIN_LEFT_INDEX];
-	bits &= MARGIN_LEFT_MASK;
-	bits >>= MARGIN_LEFT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_margin_left(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2236,17 +1470,6 @@ static inline uint8_t get_margin_left(const css_computed_style *style,
 #define MARGIN_RIGHT_INDEX 6
 #define MARGIN_RIGHT_SHIFT 25
 #define MARGIN_RIGHT_MASK 0xfe000000
-static inline uint8_t get_margin_right_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MARGIN_RIGHT_INDEX];
-	bits &= MARGIN_RIGHT_MASK;
-	bits >>= MARGIN_RIGHT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_margin_right(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2271,17 +1494,6 @@ static inline uint8_t get_margin_right(const css_computed_style *style,
 #define MARGIN_TOP_INDEX 5
 #define MARGIN_TOP_SHIFT 4
 #define MARGIN_TOP_MASK 0x7f0
-static inline uint8_t get_margin_top_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MARGIN_TOP_INDEX];
-	bits &= MARGIN_TOP_MASK;
-	bits >>= MARGIN_TOP_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_margin_top(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -2306,17 +1518,6 @@ static inline uint8_t get_margin_top(const css_computed_style *style, css_fixed
 #define MAX_HEIGHT_INDEX 5
 #define MAX_HEIGHT_SHIFT 11
 #define MAX_HEIGHT_MASK 0x3f800
-static inline uint8_t get_max_height_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MAX_HEIGHT_INDEX];
-	bits &= MAX_HEIGHT_MASK;
-	bits >>= MAX_HEIGHT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_max_height(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -2341,17 +1542,6 @@ static inline uint8_t get_max_height(const css_computed_style *style, css_fixed
 #define MAX_WIDTH_INDEX 5
 #define MAX_WIDTH_SHIFT 18
 #define MAX_WIDTH_MASK 0x1fc0000
-static inline uint8_t get_max_width_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MAX_WIDTH_INDEX];
-	bits &= MAX_WIDTH_MASK;
-	bits >>= MAX_WIDTH_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_max_width(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -2376,17 +1566,6 @@ static inline uint8_t get_max_width(const css_computed_style *style, css_fixed
 #define MIN_HEIGHT_INDEX 5
 #define MIN_HEIGHT_SHIFT 25
 #define MIN_HEIGHT_MASK 0xfe000000
-static inline uint8_t get_min_height_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MIN_HEIGHT_INDEX];
-	bits &= MIN_HEIGHT_MASK;
-	bits >>= MIN_HEIGHT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_min_height(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -2411,17 +1590,6 @@ static inline uint8_t get_min_height(const css_computed_style *style, css_fixed
 #define MIN_WIDTH_INDEX 4
 #define MIN_WIDTH_SHIFT 4
 #define MIN_WIDTH_MASK 0x7f0
-static inline uint8_t get_min_width_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[MIN_WIDTH_INDEX];
-	bits &= MIN_WIDTH_MASK;
-	bits >>= MIN_WIDTH_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_min_width(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -2446,17 +1614,6 @@ static inline uint8_t get_min_width(const css_computed_style *style, css_fixed
 #define OPACITY_INDEX 14
 #define OPACITY_SHIFT 24
 #define OPACITY_MASK 0x1000000
-static inline uint8_t get_opacity_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[OPACITY_INDEX];
-	bits &= OPACITY_MASK;
-	bits >>= OPACITY_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_opacity(const css_computed_style *style, css_fixed
 		*fixed)
 {
@@ -2480,17 +1637,6 @@ static inline uint8_t get_opacity(const css_computed_style *style, css_fixed
 #define ORDER_INDEX 14
 #define ORDER_SHIFT 25
 #define ORDER_MASK 0x2000000
-static inline uint8_t get_order_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[ORDER_INDEX];
-	bits &= ORDER_MASK;
-	bits >>= ORDER_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_order(const css_computed_style *style, int32_t
 		*integer)
 {
@@ -2514,17 +1660,6 @@ static inline uint8_t get_order(const css_computed_style *style, int32_t
 #define ORPHANS_INDEX 14
 #define ORPHANS_SHIFT 26
 #define ORPHANS_MASK 0x4000000
-static inline uint8_t get_orphans_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[ORPHANS_INDEX];
-	bits &= ORPHANS_MASK;
-	bits >>= ORPHANS_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_orphans(const css_computed_style *style, int32_t
 		*integer)
 {
@@ -2546,17 +1681,6 @@ static inline uint8_t get_orphans(const css_computed_style *style, int32_t
 #define OUTLINE_COLOR_INDEX 10
 #define OUTLINE_COLOR_SHIFT 6
 #define OUTLINE_COLOR_MASK 0xc0
-static inline uint8_t get_outline_color_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[OUTLINE_COLOR_INDEX];
-	bits &= OUTLINE_COLOR_MASK;
-	bits >>= OUTLINE_COLOR_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_outline_color(const css_computed_style *style,
 		css_color *color)
 {
@@ -2580,17 +1704,6 @@ static inline uint8_t get_outline_color(const css_computed_style *style,
 #define OUTLINE_STYLE_INDEX 5
 #define OUTLINE_STYLE_SHIFT 0
 #define OUTLINE_STYLE_MASK 0xf
-static inline uint8_t get_outline_style_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[OUTLINE_STYLE_INDEX];
-	bits &= OUTLINE_STYLE_MASK;
-	bits >>= OUTLINE_STYLE_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_outline_style(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2610,17 +1723,6 @@ static inline uint8_t get_outline_style(const css_computed_style *style)
 #define OUTLINE_WIDTH_INDEX 1
 #define OUTLINE_WIDTH_SHIFT 15
 #define OUTLINE_WIDTH_MASK 0x7f8000
-static inline uint8_t get_outline_width_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[OUTLINE_WIDTH_INDEX];
-	bits &= OUTLINE_WIDTH_MASK;
-	bits >>= OUTLINE_WIDTH_SHIFT;
-
-	/* 8bits: uuuuuttt : unit | type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_outline_width(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2645,17 +1747,6 @@ static inline uint8_t get_outline_width(const css_computed_style *style,
 #define OVERFLOW_X_INDEX 13
 #define OVERFLOW_X_SHIFT 13
 #define OVERFLOW_X_MASK 0xe000
-static inline uint8_t get_overflow_x_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[OVERFLOW_X_INDEX];
-	bits &= OVERFLOW_X_MASK;
-	bits >>= OVERFLOW_X_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_overflow_x(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2675,17 +1766,6 @@ static inline uint8_t get_overflow_x(const css_computed_style *style)
 #define OVERFLOW_Y_INDEX 13
 #define OVERFLOW_Y_SHIFT 16
 #define OVERFLOW_Y_MASK 0x70000
-static inline uint8_t get_overflow_y_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[OVERFLOW_Y_INDEX];
-	bits &= OVERFLOW_Y_MASK;
-	bits >>= OVERFLOW_Y_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_overflow_y(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2705,17 +1785,6 @@ static inline uint8_t get_overflow_y(const css_computed_style *style)
 #define PADDING_BOTTOM_INDEX 8
 #define PADDING_BOTTOM_SHIFT 14
 #define PADDING_BOTTOM_MASK 0xfc000
-static inline uint8_t get_padding_bottom_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[PADDING_BOTTOM_INDEX];
-	bits &= PADDING_BOTTOM_MASK;
-	bits >>= PADDING_BOTTOM_SHIFT;
-
-	/* 6bits: uuuuut : unit | type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_padding_bottom(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2740,17 +1809,6 @@ static inline uint8_t get_padding_bottom(const css_computed_style *style,
 #define PADDING_LEFT_INDEX 8
 #define PADDING_LEFT_SHIFT 20
 #define PADDING_LEFT_MASK 0x3f00000
-static inline uint8_t get_padding_left_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[PADDING_LEFT_INDEX];
-	bits &= PADDING_LEFT_MASK;
-	bits >>= PADDING_LEFT_SHIFT;
-
-	/* 6bits: uuuuut : unit | type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_padding_left(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2775,17 +1833,6 @@ static inline uint8_t get_padding_left(const css_computed_style *style,
 #define PADDING_RIGHT_INDEX 8
 #define PADDING_RIGHT_SHIFT 26
 #define PADDING_RIGHT_MASK 0xfc000000
-static inline uint8_t get_padding_right_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[PADDING_RIGHT_INDEX];
-	bits &= PADDING_RIGHT_MASK;
-	bits >>= PADDING_RIGHT_SHIFT;
-
-	/* 6bits: uuuuut : unit | type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_padding_right(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2810,17 +1857,6 @@ static inline uint8_t get_padding_right(const css_computed_style *style,
 #define PADDING_TOP_INDEX 3
 #define PADDING_TOP_SHIFT 5
 #define PADDING_TOP_MASK 0x7e0
-static inline uint8_t get_padding_top_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[PADDING_TOP_INDEX];
-	bits &= PADDING_TOP_MASK;
-	bits >>= PADDING_TOP_SHIFT;
-
-	/* 6bits: uuuuut : unit | type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_padding_top(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -2845,17 +1881,6 @@ static inline uint8_t get_padding_top(const css_computed_style *style,
 #define PAGE_BREAK_AFTER_INDEX 13
 #define PAGE_BREAK_AFTER_SHIFT 19
 #define PAGE_BREAK_AFTER_MASK 0x380000
-static inline uint8_t get_page_break_after_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[PAGE_BREAK_AFTER_INDEX];
-	bits &= PAGE_BREAK_AFTER_MASK;
-	bits >>= PAGE_BREAK_AFTER_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_page_break_after(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2875,18 +1900,6 @@ static inline uint8_t get_page_break_after(const css_computed_style *style)
 #define PAGE_BREAK_BEFORE_INDEX 13
 #define PAGE_BREAK_BEFORE_SHIFT 22
 #define PAGE_BREAK_BEFORE_MASK 0x1c00000
-static inline uint8_t get_page_break_before_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[PAGE_BREAK_BEFORE_INDEX];
-	bits &= PAGE_BREAK_BEFORE_MASK;
-	bits >>= PAGE_BREAK_BEFORE_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_page_break_before(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2906,18 +1919,6 @@ static inline uint8_t get_page_break_before(const css_computed_style *style)
 #define PAGE_BREAK_INSIDE_INDEX 10
 #define PAGE_BREAK_INSIDE_SHIFT 8
 #define PAGE_BREAK_INSIDE_MASK 0x300
-static inline uint8_t get_page_break_inside_bits(const css_computed_style
-		*style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[PAGE_BREAK_INSIDE_INDEX];
-	bits &= PAGE_BREAK_INSIDE_MASK;
-	bits >>= PAGE_BREAK_INSIDE_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_page_break_inside(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2937,17 +1938,6 @@ static inline uint8_t get_page_break_inside(const css_computed_style *style)
 #define POSITION_INDEX 13
 #define POSITION_SHIFT 25
 #define POSITION_MASK 0xe000000
-static inline uint8_t get_position_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[POSITION_INDEX];
-	bits &= POSITION_MASK;
-	bits >>= POSITION_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_position(const css_computed_style *style)
 {
 	uint8_t type;
@@ -2967,17 +1957,6 @@ static inline uint8_t get_position(const css_computed_style *style)
 #define QUOTES_INDEX 14
 #define QUOTES_SHIFT 27
 #define QUOTES_MASK 0x8000000
-static inline uint8_t get_quotes_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[QUOTES_INDEX];
-	bits &= QUOTES_MASK;
-	bits >>= QUOTES_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_quotes(const css_computed_style *style, lwc_string
 		***string_arr)
 {
@@ -2999,17 +1978,6 @@ static inline uint8_t get_quotes(const css_computed_style *style, lwc_string
 #define RIGHT_INDEX 4
 #define RIGHT_SHIFT 11
 #define RIGHT_MASK 0x3f800
-static inline uint8_t get_right_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[RIGHT_INDEX];
-	bits &= RIGHT_MASK;
-	bits >>= RIGHT_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_right(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -3034,17 +2002,6 @@ static inline uint8_t get_right(const css_computed_style *style, css_fixed
 #define STROKE_OPACITY_INDEX 13
 #define STROKE_OPACITY_SHIFT 0
 #define STROKE_OPACITY_MASK 0x1
-static inline uint8_t get_stroke_opacity_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[STROKE_OPACITY_INDEX];
-	bits &= STROKE_OPACITY_MASK;
-	bits >>= STROKE_OPACITY_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_stroke_opacity(const css_computed_style *style,
 		css_fixed *fixed)
 {
@@ -3068,17 +2025,6 @@ static inline uint8_t get_stroke_opacity(const css_computed_style *style,
 #define TABLE_LAYOUT_INDEX 10
 #define TABLE_LAYOUT_SHIFT 10
 #define TABLE_LAYOUT_MASK 0xc00
-static inline uint8_t get_table_layout_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[TABLE_LAYOUT_INDEX];
-	bits &= TABLE_LAYOUT_MASK;
-	bits >>= TABLE_LAYOUT_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_table_layout(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3098,17 +2044,6 @@ static inline uint8_t get_table_layout(const css_computed_style *style)
 #define TEXT_ALIGN_INDEX 4
 #define TEXT_ALIGN_SHIFT 0
 #define TEXT_ALIGN_MASK 0xf
-static inline uint8_t get_text_align_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[TEXT_ALIGN_INDEX];
-	bits &= TEXT_ALIGN_MASK;
-	bits >>= TEXT_ALIGN_SHIFT;
-
-	/* 4bits: tttt : type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_text_align(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3128,17 +2063,6 @@ static inline uint8_t get_text_align(const css_computed_style *style)
 #define TEXT_DECORATION_INDEX 3
 #define TEXT_DECORATION_SHIFT 0
 #define TEXT_DECORATION_MASK 0x1f
-static inline uint8_t get_text_decoration_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[TEXT_DECORATION_INDEX];
-	bits &= TEXT_DECORATION_MASK;
-	bits >>= TEXT_DECORATION_SHIFT;
-
-	/* 5bits: ttttt : type */
-	type = bits & 0x1f;
-	return type;
-}
 static inline uint8_t get_text_decoration(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3158,17 +2082,6 @@ static inline uint8_t get_text_decoration(const css_computed_style *style)
 #define TEXT_INDENT_INDEX 2
 #define TEXT_INDENT_SHIFT 0
 #define TEXT_INDENT_MASK 0x3f
-static inline uint8_t get_text_indent_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[TEXT_INDENT_INDEX];
-	bits &= TEXT_INDENT_MASK;
-	bits >>= TEXT_INDENT_SHIFT;
-
-	/* 6bits: uuuuut : unit | type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_text_indent(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -3193,17 +2106,6 @@ static inline uint8_t get_text_indent(const css_computed_style *style,
 #define TEXT_TRANSFORM_INDEX 9
 #define TEXT_TRANSFORM_SHIFT 0
 #define TEXT_TRANSFORM_MASK 0x7
-static inline uint8_t get_text_transform_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[TEXT_TRANSFORM_INDEX];
-	bits &= TEXT_TRANSFORM_MASK;
-	bits >>= TEXT_TRANSFORM_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_text_transform(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3223,17 +2125,6 @@ static inline uint8_t get_text_transform(const css_computed_style *style)
 #define TOP_INDEX 4
 #define TOP_SHIFT 18
 #define TOP_MASK 0x1fc0000
-static inline uint8_t get_top_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[TOP_INDEX];
-	bits &= TOP_MASK;
-	bits >>= TOP_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_top(const css_computed_style *style, css_fixed
 		*length, css_unit *unit)
 {
@@ -3258,17 +2149,6 @@ static inline uint8_t get_top(const css_computed_style *style, css_fixed
 #define UNICODE_BIDI_INDEX 10
 #define UNICODE_BIDI_SHIFT 12
 #define UNICODE_BIDI_MASK 0x3000
-static inline uint8_t get_unicode_bidi_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[UNICODE_BIDI_INDEX];
-	bits &= UNICODE_BIDI_MASK;
-	bits >>= UNICODE_BIDI_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_unicode_bidi(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3288,17 +2168,6 @@ static inline uint8_t get_unicode_bidi(const css_computed_style *style)
 #define VERTICAL_ALIGN_INDEX 12
 #define VERTICAL_ALIGN_SHIFT 1
 #define VERTICAL_ALIGN_MASK 0x3fe
-static inline uint8_t get_vertical_align_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[VERTICAL_ALIGN_INDEX];
-	bits &= VERTICAL_ALIGN_MASK;
-	bits >>= VERTICAL_ALIGN_SHIFT;
-
-	/* 9bits: uuuuutttt : unit | type */
-	type = bits & 0xf;
-	return type;
-}
 static inline uint8_t get_vertical_align(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -3323,17 +2192,6 @@ static inline uint8_t get_vertical_align(const css_computed_style *style,
 #define VISIBILITY_INDEX 10
 #define VISIBILITY_SHIFT 14
 #define VISIBILITY_MASK 0xc000
-static inline uint8_t get_visibility_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[VISIBILITY_INDEX];
-	bits &= VISIBILITY_MASK;
-	bits >>= VISIBILITY_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_visibility(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3353,17 +2211,6 @@ static inline uint8_t get_visibility(const css_computed_style *style)
 #define WHITE_SPACE_INDEX 8
 #define WHITE_SPACE_SHIFT 0
 #define WHITE_SPACE_MASK 0x7
-static inline uint8_t get_white_space_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[WHITE_SPACE_INDEX];
-	bits &= WHITE_SPACE_MASK;
-	bits >>= WHITE_SPACE_SHIFT;
-
-	/* 3bits: ttt : type */
-	type = bits & 0x7;
-	return type;
-}
 static inline uint8_t get_white_space(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3383,17 +2230,6 @@ static inline uint8_t get_white_space(const css_computed_style *style)
 #define WIDOWS_INDEX 12
 #define WIDOWS_SHIFT 0
 #define WIDOWS_MASK 0x1
-static inline uint8_t get_widows_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[WIDOWS_INDEX];
-	bits &= WIDOWS_MASK;
-	bits >>= WIDOWS_SHIFT;
-
-	/* 1bit: t : type */
-	type = bits & 0x1;
-	return type;
-}
 static inline uint8_t get_widows(const css_computed_style *style, int32_t
 		*integer)
 {
@@ -3415,17 +2251,6 @@ static inline uint8_t get_widows(const css_computed_style *style, int32_t
 #define WIDTH_INDEX 4
 #define WIDTH_SHIFT 25
 #define WIDTH_MASK 0xfe000000
-static inline uint8_t get_width_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[WIDTH_INDEX];
-	bits &= WIDTH_MASK;
-	bits >>= WIDTH_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_width(const css_computed_style *style,
 		css_fixed_or_calc *length, css_unit *unit)
 {
@@ -3450,17 +2275,6 @@ static inline uint8_t get_width(const css_computed_style *style,
 #define WORD_SPACING_INDEX 1
 #define WORD_SPACING_SHIFT 0
 #define WORD_SPACING_MASK 0x7f
-static inline uint8_t get_word_spacing_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[WORD_SPACING_INDEX];
-	bits &= WORD_SPACING_MASK;
-	bits >>= WORD_SPACING_SHIFT;
-
-	/* 7bits: uuuuutt : unit | type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_word_spacing(const css_computed_style *style,
 		css_fixed *length, css_unit *unit)
 {
@@ -3485,17 +2299,6 @@ static inline uint8_t get_word_spacing(const css_computed_style *style,
 #define WRITING_MODE_INDEX 10
 #define WRITING_MODE_SHIFT 16
 #define WRITING_MODE_MASK 0x30000
-static inline uint8_t get_writing_mode_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[WRITING_MODE_INDEX];
-	bits &= WRITING_MODE_MASK;
-	bits >>= WRITING_MODE_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_writing_mode(const css_computed_style *style)
 {
 	uint8_t type;
@@ -3515,17 +2318,6 @@ static inline uint8_t get_writing_mode(const css_computed_style *style)
 #define Z_INDEX_INDEX 10
 #define Z_INDEX_SHIFT 18
 #define Z_INDEX_MASK 0xc0000
-static inline uint8_t get_z_index_bits(const css_computed_style *style)
-{
-	uint8_t type;
-	uint32_t bits = style->i.bits[Z_INDEX_INDEX];
-	bits &= Z_INDEX_MASK;
-	bits >>= Z_INDEX_SHIFT;
-
-	/* 2bits: tt : type */
-	type = bits & 0x3;
-	return type;
-}
 static inline uint8_t get_z_index(const css_computed_style *style, int32_t
 		*integer)
 {

--- a/src/select/select_generator.py
+++ b/src/select/select_generator.py
@@ -651,14 +651,13 @@ class CSSGroup:
 
         return t.to_string()
 
-    def print_propget(self, t, p, only_bits=False):
-        vals = [] if only_bits else p.get_param_values(pointer=True)
+    def print_propget(self, t, p):
+        vals = p.get_param_values(pointer=True)
         params = ', '.join([ 'css_computed_style *style' ]
                            + [ ' '.join(x) for x in vals ])
 
-        underscore_bits = '_bits' if only_bits else ''
-        t.append('static inline uint8_t get_{}{}(const {})'.format(
-            p.name, underscore_bits, params))
+        t.append('static inline uint8_t get_{}(const {})'.format(
+            p.name, params))
         t.append('{')
         t.indent(1)
 
@@ -673,27 +672,26 @@ class CSSGroup:
         t.append(bits_comment)
         t.append('type = bits & {};'.format(type_mask))
 
-        if only_bits == False:
-            if p.condition:
-                t.append('if (type == {}) {{'.format(p.condition))
-                t.indent(1)
+        if p.condition:
+            t.append('if (type == {}) {{'.format(p.condition))
+            t.indent(1)
 
-            for v in p.values:
-                print(f"name: {p.name}, has_calc: {p.has_calc}, v.name: {v.name}")
-                i_dot = '' if v.is_ptr and v.name != 'string' else 'i.'
-                t.append('*{} = style->{}{};'.format(
-                    v.name + v.suffix, i_dot, p.name + v.suffix))
-            for i, v in enumerate(list(reversed(shift_list))):
-                if i == 0:
-                    t.append('*{} = bits >> {};'.format(v[0], v[1]))
-                else:
-                    t.append('*{} = (bits & 0x{:x}) >> {};'.format(
-                        v[0], v[2], v[1]).lower())
+        for v in p.values:
+            print(f"name: {p.name}, has_calc: {p.has_calc}, v.name: {v.name}")
+            i_dot = '' if v.is_ptr and v.name != 'string' else 'i.'
+            t.append('*{} = style->{}{};'.format(
+                v.name + v.suffix, i_dot, p.name + v.suffix))
+        for i, v in enumerate(list(reversed(shift_list))):
+            if i == 0:
+                t.append('*{} = bits >> {};'.format(v[0], v[1]))
+            else:
+                t.append('*{} = (bits & 0x{:x}) >> {};'.format(
+                    v[0], v[2], v[1]).lower())
 
-            if p.condition:
-                t.indent(-1)
-                t.append('}')
-            t.append()
+        if p.condition:
+            t.indent(-1)
+            t.append('}')
+        t.append()
 
         t.append('return type;')
 
@@ -709,8 +707,6 @@ class CSSGroup:
 
             t.append()
             t.append(defines)
-
-            self.print_propget(t, p, True)
 
             if p.name in overrides['get']:
                 t.append(overrides['get'][p.name], pre_formatted=True)


### PR DESCRIPTION
The generated `_bits` getters are not used any more.