### PR TITLE
parse: flex: parse flex-shrink before flex-basis in the shorthand

### DIFF
--- a/src/parse/properties/flex.c
+++ b/src/parse/properties/flex.c
@@ -119,18 +119,18 @@ css_error css__parse_flex(css_language *c,
 			goto css__parse_flex_cleanup;
 		}
 
-		if ((grow) && 
+		if ((grow) &&
 			   (error = css__parse_flex_grow(c, vector,
 				ctx, grow_style)) == CSS_OK) {
 			grow = false;
-		} else if ((basis) && 
-			   (error = css__parse_flex_basis(c, vector, 
-				ctx, basis_style)) == CSS_OK) {
-			basis = false;
-		} else if ((shrink) && 
-			   (error = css__parse_flex_shrink(c, vector, 
+		} else if ((shrink) &&
+			   (error = css__parse_flex_shrink(c, vector,
 				ctx, shrink_style)) == CSS_OK) {
 			shrink = false;
+		} else if ((basis) &&
+			   (error = css__parse_flex_basis(c, vector,
+				ctx, basis_style)) == CSS_OK) {
+			basis = false;
 		}
 
 		if (error == CSS_OK) {

--- a/test/data/parse2/flexbox.dat
+++ b/test/data/parse2/flexbox.dat
@@ -1274,6 +1274,36 @@
 #reset
 
 #data
+* { flex: 0 0 600px; }
+#errors
+#expected
+| *
+|  flex-grow: 0
+|  flex-shrink: 0
+|  flex-basis: 600px
+#reset
+
+#data
+* { flex: 0 0; }
+#errors
+#expected
+| *
+|  flex-grow: 0
+|  flex-shrink: 0
+|  flex-basis: 0px
+#reset
+
+#data
+* { flex: 1 0; }
+#errors
+#expected
+| *
+|  flex-grow: 1
+|  flex-shrink: 0
+|  flex-basis: 0px
+#reset
+
+#data
 * { flex: none; }
 #errors
 #expected
@@ -1382,6 +1412,16 @@
 |  flex-grow: 10 !important
 |  flex-shrink: 20 !important
 |  flex-basis: 30px !important
+#reset
+
+#data
+* { flex: 0 0 600px !important; }
+#errors
+#expected
+| *
+|  flex-grow: 0 !important
+|  flex-shrink: 0 !important
+|  flex-basis: 600px !important
 #reset
 
 #data


### PR DESCRIPTION
The flex shorthand loop tried the longhands in the order grow, basis, shrink.  Because the flex-basis <length> parser also accepts a bare 0, `flex: 0 0 600px` mis-assigned the second 0 to flex-basis and was then left with 600px to parse as flex-shrink (a <number>), which fails and invalidates the whole declaration.

The two <number> values are flex-grow and flex-shrink, so try shrink before basis; a unit-bearing length or percentage still falls through to basis.